### PR TITLE
Fixing variable length integer encoding

### DIFF
--- a/src/ser/packet_writer.rs
+++ b/src/ser/packet_writer.rs
@@ -99,23 +99,23 @@ impl<'a> ReversedPacketWriter<'a> {
 
         if value & (0b0111_1111 << 21) > 0 {
             let data: [u8; 4] = [
-                (value >> 21) as u8 & 0x7F,
-                (value >> 14) as u8 | 0x80,
-                (value >> 7) as u8 | 0x80,
                 (value >> 0) as u8 | 0x80,
+                (value >> 7) as u8 | 0x80,
+                (value >> 14) as u8 | 0x80,
+                (value >> 21) as u8 & 0x7F,
             ];
 
             self.write(&data)
         } else if value & (0b0111_1111 << 14) > 0 {
             let data: [u8; 3] = [
-                (value >> 14) as u8 & 0x7F,
-                (value >> 7) as u8 | 0x80,
                 (value >> 0) as u8 | 0x80,
+                (value >> 7) as u8 | 0x80,
+                (value >> 14) as u8 & 0x7F,
             ];
 
             self.write(&data)
         } else if value & (0b0111_1111 << 7) > 0 {
-            let data: [u8; 2] = [(value >> 7) as u8 & 0x7F, (value >> 0) as u8 | 0x80];
+            let data: [u8; 2] = [(value >> 0) as u8 | 0x80, ((value >> 7) & 0x7F) as u8];
 
             self.write(&data)
         } else {


### PR DESCRIPTION
This PR fixes #7 by correcting the encoding for variable length integers. The order was previously reversed.

Testing:
* An MQTT publish packet was generated with a size of 386. It was confirmed that the packet was properly digested by the broker.