### PR TITLE
Updating embedded-nal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,14 @@ license = "MIT"
 [dependencies]
 bit_field = "0.10.0"
 enum-iterator = "0.6.0"
-nb = "0.1.2"
 heapless = "0.5.5"
 generic-array = "0.14.3"
 log = {version = "0.4", optional = true}
+embedded-nal = "0.1.0"
 
 [features]
+default = []
 logging = ["log"]
 
 [dev-dependencies]
 env_logger = "0.7"
-
-[dependencies.embedded-nal]
-git = "https://github.com/thejpster/embedded-nal"

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -7,11 +7,10 @@ use crate::{
 
 use core::cell::RefCell;
 
-use embedded_nal::{IpAddr, Mode, SocketAddr};
+use embedded_nal::{nb, IpAddr, Mode, SocketAddr};
 
 use generic_array::{ArrayLength, GenericArray};
 use heapless::String;
-use nb;
 
 /// A client for interacting with an MQTT Broker.
 pub struct MqttClient<T, N>

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,11 +1,10 @@
 use minimq::{consts, MqttClient, Property, QoS};
 
-use nb;
 use std::cell::RefCell;
 use std::io::{self, Read, Write};
 use std::net::{self, TcpStream};
 
-use embedded_nal::{self, IpAddr, Ipv4Addr, SocketAddr};
+use embedded_nal::{self, nb, IpAddr, Ipv4Addr, SocketAddr};
 
 struct StandardStack {
     stream: RefCell<Option<TcpStream>>,


### PR DESCRIPTION
This PR fixes #9 by removing the embedded-nal github reference in favor of the crates.io version to allow for publishing.