### PR TITLE
Updating poll closure to be mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+This document describes the changes to Minimq between releases.
+
+# Unpublished
+* Updating the `MqttClient::poll()` function to take a `FnMut` closure to allow internal state
+  mutation.
+* Use the `std-embedded-nal` crate as a dependency to provide a standard `NetworkStack` for
+  integration tests.
+
+## Version 0.1.0
+Version 0.1.0 was published on 2020-08-27
+
+* Initial library release and publish to crates.io


### PR DESCRIPTION
This PR updates the internal `poll()` closure argument to be a `FnMut` to allow state mutation.

This fixes #16 

Changes have been tested with an MQTT client embedded on a real device mutating state in response to subscribed topic messages.

This PR also adds in a changelog markdown file for tracking repository changes.