### PR TITLE
Updating is_connected() function

### DIFF
--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -190,7 +190,7 @@ where
     /// Determine if the client has established a connection with the broker.
     ///
     /// # Returns
-    /// True if the client has sent a request to establish an MQTT connection.
+    /// True if the client is connected to the broker.
     pub fn is_connected(&self) -> Result<bool, Error<N::Error>> {
         Ok(self.socket_is_connected()? && self.connect_sent)
     }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -191,8 +191,8 @@ where
     ///
     /// # Returns
     /// True if the client has sent a request to establish an MQTT connection.
-    pub fn is_connected(&self) -> bool {
-        self.connect_sent
+    pub fn is_connected(&self) -> Result<bool, Error<N::Error>> {
+        Ok(self.socket_is_connected()? && self.connect_sent)
     }
 
     /// Publish a message over MQTT.
@@ -220,7 +220,7 @@ where
         assert!(qos == QoS::AtMostOnce);
 
         // If we are not yet connected to the broker, we can't transmit a message.
-        if self.is_connected() == false {
+        if self.is_connected()? == false {
             return Ok(());
         }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,7 +35,7 @@ fn main() -> std::io::Result<()> {
             .unwrap();
 
         if !subscribed {
-            if client.is_connected() {
+            if client.is_connected().unwrap() {
                 client.subscribe("response", &[]).unwrap();
                 client.subscribe("request", &[]).unwrap();
                 subscribed = true;


### PR DESCRIPTION
This PR fixes #19 by updating the `publish()` function to check if a connection with the broker exists before sending a message.