### PR TITLE
Updating nb result handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This document describes the changes to Minimq between releases.
   mutation.
 * Use the `std-embedded-nal` crate as a dependency to provide a standard `NetworkStack` for
   integration tests.
+* Updating `read()` to not block when no data is available. Updating `write()` to progate network
+  stack errors out to the user.
 
 ## Version 0.1.0
 Version 0.1.0 was published on 2020-08-27

--- a/examples/minimq-stm32h7/Cargo.lock
+++ b/examples/minimq-stm32h7/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.6.0"
-source = "git+https://github.com/smoltcp-rs/smoltcp?branch=master#bdfa44270e9c59b3095b555cdf14601f7dc27794"
+source = "git+https://github.com/smoltcp-rs/smoltcp#bdfa44270e9c59b3095b555cdf14601f7dc27794"
 dependencies = [
  "bitflags",
  "byteorder",


### PR DESCRIPTION
This PR removes the `nb::block!()` during read requests to prevent inadvertent blocking. Instead, the read request returns 0, indicating no data read.

This also propagates a network error out of MiniMQ and removes an unwrap.

This fixes #25 