### PR TITLE
Preparing for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This document describes the changes to Minimq between releases.
 
-# Unpublished
+# Unrelease
+
+# Version 0.2.0
+Version 0.2.0 was published on 2021-02-15
+
 * Updating the `MqttClient::poll()` function to take a `FnMut` closure to allow internal state
   mutation.
 * Use the `std-embedded-nal` crate as a dependency to provide a standard `NetworkStack` for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimq"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>", "Max Rottenkolber <max@mr.gy>"]
 edition = "2018"
 


### PR DESCRIPTION
This PR stages the 0.2.0 release of `minimq`