### PR TITLE
Feature/optional client

### DIFF
--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -85,7 +85,7 @@ where
     ///
     /// # Args
     /// * `broker` - The IP address of the broker to connect to.
-    /// * `client_id` The client ID to use for communicating with the broker. If None, rely on the
+    /// * `client_id` The client ID to use for communicating with the broker. If empty, rely on the
     ///   broker to automatically assign a client ID.
     /// * `network_stack` - The network stack to use for communication.
     ///

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -5,7 +5,7 @@ use crate::{
     Property, {debug, error, info},
 };
 
-use core::cell::RefCell;
+use core::{cell::RefCell, str::FromStr};
 
 use embedded_nal::{nb, IpAddr, Mode, SocketAddr};
 
@@ -314,7 +314,8 @@ where
                             state.maximum_packet_size.replace(size);
                         }
                         Property::AssignedClientIdentifier(id) => {
-                            state.client_id = String::from(id);
+                            state.client_id = String::from_str(id)
+                                .or(Err(Error::Protocol(ProtocolError::DataSize)))?;
                         }
                         Property::ServerKeepAlive(keep_alive) => {
                             state.keep_alive_interval = keep_alive;

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -103,7 +103,8 @@ where
 
         let mut session_state = SessionState::new(broker);
         if let Some(id) = client_id {
-            session_state.client_id = String::from(id);
+            session_state.client_id =
+                String::from_str(id).or(Err(Error::Protocol(ProtocolError::DataSize)))?;
         }
 
         let mut client = MqttClient {

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -49,6 +49,7 @@ pub enum Error<E> {
     NotReady,
     Disconnected,
     Unsupported,
+    ProvidedClientIdTooLong,
     Failed(u8),
     Protocol(ProtocolError),
 }
@@ -103,8 +104,7 @@ where
 
         let mut session_state = SessionState::new(broker);
         if let Some(id) = client_id {
-            session_state.client_id =
-                String::from_str(id).or(Err(Error::Protocol(ProtocolError::DataSize)))?;
+            session_state.client_id = String::from_str(id).or(Err(Error::ProvidedClientIdTooLong))?;
         }
 
         let mut client = MqttClient {
@@ -316,7 +316,7 @@ where
                         }
                         Property::AssignedClientIdentifier(id) => {
                             state.client_id = String::from_str(id)
-                                .or(Err(Error::Protocol(ProtocolError::DataSize)))?;
+                                .or(Err(Error::ProvidedClientIdTooLong))?;
                         }
                         Property::ServerKeepAlive(keep_alive) => {
                             state.keep_alive_interval = keep_alive;

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -23,16 +23,6 @@ pub fn connect_message<'a, 'b>(
     keep_alive: u16,
     properties: &[Property<'a>],
 ) -> Result<&'b [u8], Error> {
-    for i in 0..client_id.len() {
-        if !(client_id[i] - 0x30 <=  9 || // 0-9
-             client_id[i] - 0x41 <= 25 || // A-Z
-             client_id[i] - 0x61 <= 25)
-        {
-            // a-z
-            return Err(Error::Bounds);
-        }
-    }
-
     // Validate the properties for this packet.
     for property in properties {
         match property.id() {

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -9,7 +9,7 @@ pub struct SessionState {
     pub keep_alive_interval: u16,
     pub broker: IpAddr,
     pub maximum_packet_size: Option<u32>,
-    pub client_id: String<consts::U32>,
+    pub client_id: String<consts::U64>,
     pub pending_subscriptions: Vec<u16, consts::U32>,
     packet_id: u16,
 }

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -15,11 +15,11 @@ pub struct SessionState {
 }
 
 impl SessionState {
-    pub fn new<'a>(broker: IpAddr, id: &'a str) -> SessionState {
+    pub fn new(broker: IpAddr) -> SessionState {
         SessionState {
             connected: false,
             broker,
-            client_id: String::from(id),
+            client_id: String::new(),
             packet_id: 1,
             keep_alive_interval: 0,
             pending_subscriptions: Vec::new(),

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -15,11 +15,11 @@ pub struct SessionState {
 }
 
 impl SessionState {
-    pub fn new(broker: IpAddr) -> SessionState {
+    pub fn new<'a>(broker: IpAddr, id: String<consts::U64>) -> SessionState {
         SessionState {
             connected: false,
             broker,
-            client_id: String::new(),
+            client_id: id,
             packet_id: 1,
             keep_alive_interval: 0,
             pending_subscriptions: Vec::new(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,7 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::STACK.clone();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut client =
-        MqttClient::<consts::U256, _>::new(localhost, "IntegrationTest", stack).unwrap();
+        MqttClient::<consts::U256, _>::new(localhost, None, stack).unwrap();
 
     let mut published = false;
     let mut subscribed = false;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,8 +8,7 @@ fn main() -> std::io::Result<()> {
 
     let stack = std_embedded_nal::STACK.clone();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut client =
-        MqttClient::<consts::U256, _>::new(localhost, None, stack).unwrap();
+    let mut client = MqttClient::<consts::U256, _>::new(localhost, None, stack).unwrap();
 
     let mut published = false;
     let mut subscribed = false;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,7 +8,7 @@ fn main() -> std::io::Result<()> {
 
     let stack = std_embedded_nal::STACK.clone();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut client = MqttClient::<consts::U256, _>::new(localhost, None, stack).unwrap();
+    let mut client = MqttClient::<consts::U256, _>::new(localhost, "", stack).unwrap();
 
     let mut published = false;
     let mut subscribed = false;


### PR DESCRIPTION
This PR fixes #30 by making the client ID optional. Additionally, the overly-strict client ID check has been removed to allow broker-mediated client IDs.