### PR TITLE
Feature/session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 This document describes the changes to Minimq between releases.
 
-# Unrelease
+# Unreleased
 * Client ID may now be unspecified to allow the broker to automatically assign an ID.
 * Strict client ID check removed to allow broker-validated IDs.
 * Updated `generic-array` dependencies to address security vulnerability.
 * Updating `new()` to allow the network stack to be non-functional during initialization.
 * `Property` updated to implement `Copy`/`Clone`.
+* Session state is now maintained
+* `Error::SessionReset` can be used to detect need to resubscribe to topics.
 
 # Version 0.2.0
 Version 0.2.0 was published on 2021-02-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 [dependencies]
 bit_field = "0.10.0"
 enum-iterator = "0.6.0"
-heapless = ">=0.6.1"
+heapless = "0.6.1"
 generic-array = ">=0.14.4"
 log = {version = "0.4", optional = true}
 embedded-nal = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,5 @@ There is also an example on a standard computer in `tests/integration_test.rs`
 ## Not yet implemented features.
 
 - Support all QoS levels
-- Support maintained session states
 - Implement keepalive timeouts
 - Allow batch subscriptions to multiple topics

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -22,9 +22,8 @@ where
     pub network_stack: N,
 
     socket: RefCell<Option<N::TcpSocket>>,
-    state: RefCell<SessionState>,
+    session_state: SessionState,
     packet_reader: PacketReader<T>,
-    transmit_buffer: RefCell<GenericArray<u8, T>>,
     connect_sent: bool,
 }
 
@@ -52,6 +51,7 @@ pub enum Error<E> {
     ProvidedClientIdTooLong,
     Failed(u8),
     Protocol(ProtocolError),
+    SessionReset,
 }
 
 /// Errors that are specific to the MQTT protocol implementation.
@@ -100,8 +100,7 @@ where
         let mut client = MqttClient {
             network_stack: network_stack,
             socket: RefCell::new(None),
-            state: RefCell::new(session_state),
-            transmit_buffer: RefCell::new(GenericArray::default()),
+            session_state,
             packet_reader: PacketReader::new(),
             connect_sent: false,
         };
@@ -151,33 +150,29 @@ where
     /// * `topic` - The topic to subscribe to.
     /// * `properties` - A list of properties to attach to the subscription request. May be empty.
     pub fn subscribe<'a, 'b>(
-        &self,
+        &mut self,
         topic: &'a str,
         properties: &[Property<'b>],
     ) -> Result<(), Error<N::Error>> {
-        let mut state = self.state.borrow_mut();
-
         if !self.connect_sent {
             return Err(Error::NotReady);
         }
-        let packet_id = state.get_packet_identifier();
 
-        let mut buffer = self.transmit_buffer.borrow_mut();
+        let packet_id = self.session_state.get_packet_identifier();
+
+        let mut buffer: GenericArray<u8, T> = GenericArray::default();
         let packet = serialize::subscribe_message(&mut buffer, topic, packet_id, properties)
             .map_err(|e| Error::Protocol(e))?;
 
-        match self.write(packet) {
-            Ok(_) => {
-                info!("Subscribing to `{}`: {}", topic, packet_id);
-                state
-                    .pending_subscriptions
-                    .push(packet_id)
-                    .map_err(|_| Error::Unsupported)?;
-                state.increment_packet_identifier();
-                Ok(())
-            }
-            Err(e) => Err(e),
-        }
+        self.write(packet).and_then(|_| {
+            info!("Subscribing to `{}`: {}", topic, packet_id);
+            self.session_state
+                .pending_subscriptions
+                .push(packet_id)
+                .map_err(|_| Error::Unsupported)?;
+            self.session_state.increment_packet_identifier();
+            Ok(())
+        })
     }
 
     /// Determine if any subscriptions are waiting for completion.
@@ -185,7 +180,7 @@ where
     /// # Returns
     /// True if any subscriptions are waiting for confirmation from the broker.
     pub fn subscriptions_pending(&self) -> bool {
-        self.state.borrow().pending_subscriptions.len() != 0
+        self.session_state.pending_subscriptions.len() != 0
     }
 
     /// Determine if the client has established a connection with the broker.
@@ -230,7 +225,7 @@ where
             topic, data, properties
         );
 
-        let mut buffer = self.transmit_buffer.borrow_mut();
+        let mut buffer: GenericArray<u8, T> = GenericArray::default();
         let packet = serialize::publish_message(&mut buffer, topic, data, properties)
             .map_err(|e| Error::Protocol(e))?;
         self.write(packet)
@@ -252,7 +247,6 @@ where
     }
 
     fn reset(&mut self) -> Result<(), Error<N::Error>> {
-        self.state.borrow_mut().reset();
         self.packet_reader.reset();
         self.connect_sent = false;
 
@@ -262,14 +256,21 @@ where
     fn connect_to_broker(&mut self) -> Result<(), Error<N::Error>> {
         self.reset()?;
 
-        let mut buffer = self.transmit_buffer.borrow_mut();
+        let properties = [
+            // Tell the broker our maximum packet size.
+            Property::MaximumPacketSize(self.packet_reader.maximum_packet_length() as u32),
+            // The session does not expire.
+            Property::SessionExpiryInterval(u32::MAX),
+        ];
+
+        let mut buffer: GenericArray<u8, T> = GenericArray::default();
         let packet = serialize::connect_message(
             &mut buffer,
-            self.state.borrow().client_id.as_str().as_bytes(),
-            self.state.borrow().keep_alive_interval,
-            &[Property::MaximumPacketSize(
-                self.packet_reader.maximum_packet_length() as u32,
-            )],
+            self.session_state.client_id.as_str().as_bytes(),
+            self.session_state.keep_alive_interval,
+            &properties,
+            // Only perform a clean start if we have never connected before.
+            !self.session_state.connected,
         )
         .map_err(|e| Error::Protocol(e))?;
 
@@ -281,45 +282,52 @@ where
         Ok(())
     }
 
-    fn handle_packet<'p, F>(
-        &self,
-        packet: ReceivedPacket<'p>,
-        f: &mut F,
-    ) -> Result<(), Error<N::Error>>
+    fn handle_packet<F>(&mut self, f: &mut F) -> Result<(), Error<N::Error>>
     where
         for<'a> F: FnMut(&Self, &'a str, &[u8], &[Property<'a>]),
     {
-        let mut state = self.state.borrow_mut();
-        if !state.connected {
+        let packet =
+            ReceivedPacket::parse_message(&self.packet_reader).map_err(|e| Error::Protocol(e))?;
+
+        info!("Received {:?}", packet);
+
+        if !self.session_state.connected {
             if let ReceivedPacket::ConnAck(acknowledge) = packet {
+                let mut result = Ok(());
+
                 if acknowledge.reason_code != 0 {
                     return Err(Error::Failed(acknowledge.reason_code));
                 }
 
-                if acknowledge.session_present {
-                    // We do not currently support saved session state.
-                    return Err(Error::Unsupported);
+                if !acknowledge.session_present {
+                    if self.session_state.connected {
+                        result = Err(Error::SessionReset);
+                    }
+
+                    // Reset the session state upon connection with a broker that doesn't have a
+                    // session state saved for us.
+                    self.session_state.reset();
                 }
 
-                state.connected = true;
+                self.session_state.connected = true;
 
                 for property in acknowledge.properties {
                     match property {
                         Property::MaximumPacketSize(size) => {
-                            state.maximum_packet_size.replace(size);
+                            self.session_state.maximum_packet_size.replace(size);
                         }
                         Property::AssignedClientIdentifier(id) => {
-                            state.client_id =
+                            self.session_state.client_id =
                                 String::from_str(id).or(Err(Error::ProvidedClientIdTooLong))?;
                         }
                         Property::ServerKeepAlive(keep_alive) => {
-                            state.keep_alive_interval = keep_alive;
+                            self.session_state.keep_alive_interval = keep_alive;
                         }
                         _prop => info!("Ignoring property: {:?}", _prop),
                     };
                 }
 
-                return Ok(());
+                return result;
             } else {
                 // It is a protocol error to receive anything else when not connected.
                 // TODO: Verify it is a protocol error.
@@ -344,7 +352,8 @@ where
             }
 
             ReceivedPacket::SubAck(subscribe_acknowledge) => {
-                match state
+                match self
+                    .session_state
                     .pending_subscriptions
                     .iter()
                     .position(|v| *v == subscribe_acknowledge.packet_identifier)
@@ -353,7 +362,7 @@ where
                         error!("Got bad suback: {:?}", subscribe_acknowledge);
                         return Err(Error::Protocol(ProtocolError::Invalid));
                     }
-                    Some(index) => state.pending_subscriptions.swap_remove(index),
+                    Some(index) => self.session_state.pending_subscriptions.swap_remove(index),
                 };
 
                 if subscribe_acknowledge.reason_code != 0 {
@@ -375,7 +384,7 @@ where
         // TODO: Limit the time between connect attempts to prevent network spam.
         let socket = self
             .network_stack
-            .connect(socket, SocketAddr::new(self.state.borrow().broker, 1883))?;
+            .connect(socket, SocketAddr::new(self.session_state.broker, 1883))?;
 
         // Store the new socket for future use.
         socket_ref.replace(socket);
@@ -433,15 +442,15 @@ where
 
             // Handle any received packets.
             while self.packet_reader.packet_available() {
-                // TODO: Handle deserialize errors properly.
-                let packet = ReceivedPacket::parse_message(&self.packet_reader)
-                    .map_err(|e| Error::Protocol(e))?;
+                let result = self.handle_packet(&mut f);
 
-                info!("Received {:?}", packet);
-                self.handle_packet(packet, &mut f)?;
                 self.packet_reader
                     .pop_packet()
                     .map_err(|e| Error::Protocol(e))?;
+
+                // If there was an error, return it now. Note that we ensure the packet is removed
+                // from buffering after processing even in error conditions..
+                result?;
             }
         }
 

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -5,6 +5,7 @@ use embedded_nal::IpAddr;
 use heapless::{consts, String, Vec};
 
 pub struct SessionState {
+    // Indicates that we are connected to a broker.
     pub connected: bool,
     pub keep_alive_interval: u16,
     pub broker: IpAddr,
@@ -12,12 +13,14 @@ pub struct SessionState {
     pub client_id: String<consts::U64>,
     pub pending_subscriptions: Vec<u16, consts::U32>,
     packet_id: u16,
+    active: bool,
 }
 
 impl SessionState {
     pub fn new<'a>(broker: IpAddr, id: String<consts::U64>) -> SessionState {
         SessionState {
             connected: false,
+            active: false,
             broker,
             client_id: id,
             packet_id: 1,
@@ -28,11 +31,22 @@ impl SessionState {
     }
 
     pub fn reset(&mut self) {
+        self.active = false;
         self.connected = false;
         self.packet_id = 1;
         self.keep_alive_interval = 0;
         self.maximum_packet_size = None;
         self.pending_subscriptions.clear();
+    }
+
+    /// Called whenever an active connection has been made with a broker.
+    pub fn register_connection(&mut self) {
+        self.active = true;
+    }
+
+    /// Indicates if there is present session state available.
+    pub fn is_present(&self) -> bool {
+        self.active
     }
 
     pub fn get_packet_identifier(&mut self) -> u16 {


### PR DESCRIPTION
The PR adds support for maintaining MQTT session state. This eliminates the need to resubscribe to topics for every network disconnection.

This fixes #42 

This PR also updates ownership semantics to remove many of the RefCells used throughout.