### PR TITLE
Removing blocking write

### DIFF
--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -129,7 +129,13 @@ where
     fn write(&self, buf: &[u8]) -> Result<(), Error<N::Error>> {
         let mut socket_ref = self.socket.borrow_mut();
         let mut socket = socket_ref.take().unwrap();
-        let written = nb::block!(self.network_stack.write(&mut socket, &buf))?;
+        let written = self
+            .network_stack
+            .write(&mut socket, &buf)
+            .map_err(|err| match err {
+                nb::Error::WouldBlock => Error::WriteFail,
+                nb::Error::Other(err) => Error::Network(err),
+            })?;
 
         // Put the socket back into the option.
         socket_ref.replace(socket);


### PR DESCRIPTION
This PR fixes #38 by replacing the nb::block!() call with an error mapping to `Error::WriteFail`, as blocking may never complete (e.g. for network stacks like smoltcp that need software processing of ingress/egress).