### PR TITLE
Refactoring state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document describes the changes to Minimq between releases.
 * Refactoring client into `Minimq` and `MqttClient` to solve internal mutability issues.
 * Updating to `embedded-nal` v0.6
 * Removing using of `generic-array` in favor of const-generics.
+* Correcting an issue where the client would not reconnect if the broker was restarted.
 
 # Version 0.2.0
 Version 0.2.0 was published on 2021-02-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bit_field = "0.10.0"
 enum-iterator = "0.6.0"
 heapless = "0.7"
 log = {version = "0.4", optional = true}
+smlang = "0.4"
 
 [dependencies.embedded-nal]
 version = "0.6"

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -118,7 +118,9 @@ where
 
                 // Allocate a new socket to use and begin connecting it.
                 self.socket.replace(self.network_stack.socket()?);
-                self.connection_state.process_event(Events::GotSocket).unwrap();
+                self.connection_state
+                    .process_event(Events::GotSocket)
+                    .unwrap();
             }
 
             // In the connect transport state, we need to connect our TCP socket to the broker.
@@ -159,7 +161,9 @@ where
                 info!("Sending CONNECT");
                 self.write(packet)?;
 
-                self.connection_state.process_event(Events::SentConnect).unwrap();
+                self.connection_state
+                    .process_event(Events::SentConnect)
+                    .unwrap();
             }
 
             _ => {}

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -65,9 +65,9 @@ mod sm {
 
     statemachine! {
         transitions: {
-            *Restart + Update = ConnectTransport,
+            *Restart + GotSocket = ConnectTransport,
             ConnectTransport + Connect = ConnectBroker,
-            ConnectBroker + Update = Active,
+            ConnectBroker + SentConnect = Active,
             ConnectBroker + Disconnect = Restart,
             Active + Disconnect = Restart,
         }
@@ -118,7 +118,7 @@ where
 
                 // Allocate a new socket to use and begin connecting it.
                 self.socket.replace(self.network_stack.socket()?);
-                self.connection_state.process_event(Events::Update).unwrap();
+                self.connection_state.process_event(Events::GotSocket).unwrap();
             }
 
             // In the connect transport state, we need to connect our TCP socket to the broker.
@@ -159,7 +159,7 @@ where
                 info!("Sending CONNECT");
                 self.write(packet)?;
 
-                self.connection_state.process_event(Events::Update).unwrap();
+                self.connection_state.process_event(Events::SentConnect).unwrap();
             }
 
             _ => {}


### PR DESCRIPTION
This PR fixes #28 by refactoring state management within `minimq` to properly track various connection state details. Notably, now, after an active connection is lost, `minimq` will `close()` the current socket so that the transmit portion of the socket also closes. This was previously holding up (re)connection attempts, as the socket was still partially connected.

This PR unifies all of the connection state management into a logical sequence of steps.

TODO:
- [x] Verify state transitions are valid before accepting them.