### PR TITLE
Replace ad-hoc std-based NAL with std-embedded-nal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document describes the changes to Minimq between releases.
 
+# Unreleased
+
+* Updating to `std-embedded-nal` v0.1 (dev dependency only; now again used for integration tests)
+
 # Version 0.3.0
 Version 0.3.0 was published on 2021-08-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ logging = ["log"]
 
 [dev-dependencies]
 env_logger = "0.7"
-std-embedded-nal = "=0.0.1"
+std-embedded-nal = "0.1"


### PR DESCRIPTION
This is doing b0b60b2e again after 2f4dd69f reintroduced a local version
due to std-embedded-nal lagging behind embedded-nal development.

---

Thanks to your [PR](https://gitlab.com/chrysn/std-embedded-nal/-/merge_requests/2), std-embedded-nal is again at state-of-the-art embedded-nal level.

Alternatively to this, if std-embedded-nal is too slow to adapt, it should probably be removed from dev-dependencies.

(As an alternative to the alternative, given that maintaining the code removed here is very similar to the steps in maintaining std-embedded-nal, I'd be happy to invite you to become comaintainer of that crate).