### PR TITLE
Adding keep-alive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This document describes the changes to Minimq between releases.
 # Unreleased
 
 * Updating to `std-embedded-nal` v0.1 (dev dependency only; now again used for integration tests)
+* Added support for PingReq/PingResp to handle broken TCP connections and configuration of the
+keep-alive interval
 
 # Version 0.3.0
 Version 0.3.0 was published on 2021-08-06

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ enum-iterator = "0.6.0"
 heapless = "0.7"
 log = {version = "0.4", optional = true}
 smlang = "0.4"
+embedded-time = "0.12"
 
 [dependencies.embedded-nal]
 version = "0.6"

--- a/README.md
+++ b/README.md
@@ -15,5 +15,4 @@ There is also an example on a standard computer in `tests/integration_test.rs`
 ## Not yet implemented features.
 
 - Support all QoS levels
-- Implement keepalive timeouts
 - Allow batch subscriptions to multiple topics

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -224,6 +224,28 @@ where
             })
     }
 
+    /// Configure the MQTT keep-alive interval.
+    ///
+    /// # Note
+    /// This must be completed before connecting to a broker.
+    ///
+    /// # Note
+    /// The broker may override the requested keep-alive interval. Any value requested by the
+    /// broker will be used instead.
+    ///
+    /// # Args
+    /// * `interval` - The keep-alive interval in seconds. A ping will be transmitted if no other
+    /// messages are sent within 50% of the keep-alive interval.
+    pub fn set_keepalive_interval(&mut self, interval: u16) -> Result<(), Error<N::Error>> {
+        match self.connection_state.state() {
+            &States::Active => Err(Error::NotReady),
+            _ => {
+                self.session_state.keep_alive_interval.replace(interval);
+                Ok(())
+            }
+        }
+    }
+
     /// Subscribe to a topic.
     ///
     /// # Note

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -6,7 +6,10 @@ use crate::{
 };
 
 use embedded_nal::{nb, IpAddr, SocketAddr, TcpClientStack};
-use embedded_time::Clock;
+use embedded_time::{
+    duration::{Extensions, Seconds},
+    Clock,
+};
 
 use heapless::String;
 
@@ -129,9 +132,9 @@ where
         match self.connection_state.state() {
             // In the RESTART state, we need to reopen the TCP socket.
             &States::Restart => {
-                if self.socket.is_some() {
+                if let Some(socket) = self.socket.take() {
                     self.network_stack
-                        .close(self.socket.take().unwrap())
+                        .close(socket)
                         .map_err(|err| Error::Network(err))?;
                 }
 
@@ -174,7 +177,10 @@ where
                 let packet = serialize::connect_message(
                     &mut buffer,
                     self.session_state.client_id.as_str().as_bytes(),
-                    self.session_state.keep_alive_interval.unwrap_or(0),
+                    self.session_state
+                        .keep_alive_interval
+                        .unwrap_or(0.seconds())
+                        .0 as u16,
                     &properties,
                     // Only perform a clean start if we do not have any session state.
                     !self.session_state.is_present(),
@@ -238,11 +244,20 @@ where
     /// # Args
     /// * `interval` - The keep-alive interval in seconds. A ping will be transmitted if no other
     /// messages are sent within 50% of the keep-alive interval.
-    pub fn set_keepalive_interval(&mut self, interval: u16) -> Result<(), Error<N::Error>> {
+    pub fn set_keepalive_interval(
+        &mut self,
+        interval: impl Into<Seconds<u32>>,
+    ) -> Result<(), Error<N::Error>> {
+        let interval = interval.into();
+        if interval.0 > u16::MAX as u32 {
+            return Err(ProtocolError::Invalid.into());
+        }
         match self.connection_state.state() {
             &States::Active => Err(Error::NotReady),
             _ => {
-                self.session_state.keep_alive_interval.replace(interval);
+                self.session_state
+                    .keep_alive_interval
+                    .replace(interval.into());
                 Ok(())
             }
         }
@@ -393,7 +408,9 @@ where
                                 String::from_str(id).or(Err(Error::ProvidedClientIdTooLong))?;
                         }
                         Property::ServerKeepAlive(keep_alive) => {
-                            self.session_state.keep_alive_interval.replace(keep_alive);
+                            self.session_state
+                                .keep_alive_interval
+                                .replace((keep_alive as u32).seconds());
                         }
                         _prop => info!("Ignoring property: {:?}", _prop),
                     };

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -191,6 +191,8 @@ where
             _ => {}
         }
 
+        self.handle_timers()?;
+
         Ok(())
     }
 
@@ -455,7 +457,7 @@ where
 
     fn handle_timers(&mut self) -> Result<(), Error<N::Error>> {
         // If we are not connected, there's no session state to manage.
-        if !self.session_state.is_present() {
+        if self.connection_state.state() != &States::Active {
             return Ok(());
         }
 
@@ -541,9 +543,6 @@ impl<N: TcpClientStack, C: Clock, const T: usize> Minimq<N, C, T> {
             self.packet_reader.reset();
             return Ok(());
         }
-
-        // Process any client timers.
-        self.client.handle_timers()?;
 
         let mut buf: [u8; 1024] = [0; 1024];
         let received = self.client.read(&mut buf)?;

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -62,6 +62,10 @@ pub fn connect_message<'a, 'b>(
     packet.finalize(MessageType::Connect, 0)
 }
 
+pub fn ping_req_message<'a>(dest: &'a mut [u8]) -> Result<&'a [u8], Error> {
+    ReversedPacketWriter::new(dest).finalize(MessageType::PingReq, 0x00)
+}
+
 pub fn publish_message<'a, 'b, 'c>(
     dest: &'b mut [u8],
     topic: &'a str,
@@ -204,4 +208,15 @@ fn serialize_connect() {
     let message = connect_message(&mut buffer, client_id, 10, &[], true).unwrap();
 
     assert_eq!(message, good_serialized_connect)
+}
+
+#[test]
+fn serialize_ping_req() {
+    let good_ping_req: [u8; 2] = [
+        0xc0, // Ping
+        0x00, // Remaining length (0)
+    ];
+
+    let mut buffer: [u8; 1024] = [0; 1024];
+    assert_eq!(ping_req_message(&mut buffer).unwrap(), good_ping_req);
 }

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -77,14 +77,9 @@ impl<C: Clock> SessionState<C> {
 
     pub fn ping_is_due(&self, now: &Instant<C>) -> bool {
         // Send a ping if we haven't sent a transmission in the last 50% of the keepalive internal.
-        if let Some(keep_alive_interval) = self.keep_alive_interval {
-            if let Some(timestamp) = self.last_transmission {
-                *now > timestamp + ((keep_alive_interval * 500) as u32).milliseconds()
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        self.keep_alive_interval.zip(self.last_transmission)
+            .map_or(false, |(interval, last)|
+                *now > last + (interval as u32 * 500).milliseconds()
+            )
     }
 }

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -4,27 +4,33 @@
 use embedded_nal::IpAddr;
 use heapless::{String, Vec};
 
-pub struct SessionState {
+use embedded_time::{duration::Extensions, Clock, Instant};
+
+pub struct SessionState<C: Clock> {
     // Indicates that we are connected to a broker.
     pub connected: bool,
-    pub keep_alive_interval: u16,
+    pub keep_alive_interval: Option<u16>,
+    pub ping_timeout: Option<Instant<C>>,
     pub broker: IpAddr,
     pub maximum_packet_size: Option<u32>,
     pub client_id: String<64>,
+    last_transmission: Option<Instant<C>>,
     pub pending_subscriptions: Vec<u16, 32>,
     packet_id: u16,
     active: bool,
 }
 
-impl SessionState {
-    pub fn new<'a>(broker: IpAddr, id: String<64>) -> SessionState {
+impl<C: Clock> SessionState<C> {
+    pub fn new<'a>(broker: IpAddr, id: String<64>) -> SessionState<C> {
         SessionState {
             connected: false,
             active: false,
+            ping_timeout: None,
             broker,
             client_id: id,
             packet_id: 1,
-            keep_alive_interval: 0,
+            keep_alive_interval: Some(60),
+            last_transmission: None,
             pending_subscriptions: Vec::new(),
             maximum_packet_size: None,
         }
@@ -34,9 +40,10 @@ impl SessionState {
         self.active = false;
         self.connected = false;
         self.packet_id = 1;
-        self.keep_alive_interval = 0;
+        self.keep_alive_interval = Some(60);
         self.maximum_packet_size = None;
         self.pending_subscriptions.clear();
+        self.last_transmission = None;
     }
 
     /// Called whenever an active connection has been made with a broker.
@@ -61,6 +68,23 @@ impl SessionState {
             self.packet_id = 1;
         } else {
             self.packet_id = result;
+        }
+    }
+
+    pub fn register_transmission(&mut self, now: Instant<C>) {
+        self.last_transmission = Some(now);
+    }
+
+    pub fn ping_is_due(&self, now: &Instant<C>) -> bool {
+        // Send a ping if we haven't sent a transmission in the last 50% of the keepalive internal.
+        if let Some(keep_alive_interval) = self.keep_alive_interval {
+            if let Some(timestamp) = self.last_transmission {
+                *now > timestamp + ((keep_alive_interval * 500) as u32).milliseconds()
+            } else {
+                false
+            }
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
This PR refactors #36 after a restructure of `minimq` and implements ping request/response support.

This PR fixes #51 

## Testing
The integraton test was modified to never exit and I monitored network traffic on the loopback. I observed the ping request/response at the expected 30s interval on wireshark.