### PR TITLE
Updating dependencies and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This document describes the changes to Minimq between releases.
 * Updating to `std-embedded-nal` v0.1 (dev dependency only; now again used for integration tests)
 * Added support for PingReq/PingResp to handle broken TCP connections and configuration of the
 keep-alive interval
+* Updating tests to use `std-embedded-time`
+* Fixing main docs.
 
 # Version 0.3.0
 Version 0.3.0 was published on 2021-08-06

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ logging = ["log"]
 [dev-dependencies]
 env_logger = "0.7"
 std-embedded-nal = "0.1"
+std-embedded-time = { git = "https://github.com/quartiq/std-embedded-time", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ logging = ["log"]
 [dev-dependencies]
 env_logger = "0.7"
 std-embedded-nal = "0.1"
-std-embedded-time = { git = "https://github.com/quartiq/std-embedded-time", branch = "main" }
+std-embedded-time = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,25 +28,26 @@
 //! in `examples/minimq-stm32h7`, which targets the Nucleo-H743 development board with an external
 //! temperature sensor installed.
 //!
-//! ```ignore
-//! use minimq::{MqttClient, consts, QoS, embedded_nal::{IpAddr, Ipv4Addr}};
+//! ```no_run
+//! use minimq::{Minimq, QoS};
 //!
 //! // Construct an MQTT client with a maximum packet size of 256 bytes.
 //! // Connect to a broker at 192.168.0.254 - Use a client ID of "test".
-//! let client: MqttClient<consts::U256, _> = MqttClient::new(
-//!         IpAddr::V4(Ipv4Addr::new(192, 168, 0, 254)),
+//! let mut mqtt: Minimq<_, _, 256> = Minimq::new(
+//!         "127.0.0.1".parse().unwrap(),
 //!         "test",
-//!         tcp_stack).unwrap();
+//!         std_embedded_nal::Stack::default(),
+//!         std_embedded_time::StandardClock::default()).unwrap();
 //!
 //! let mut subscribed = false;
 //!
 //! loop {
-//!     if client.is_connected() && !subscribed {
-//!         client.subscribe("topic").unwrap();
+//!     if mqtt.client.is_connected().unwrap() && !subscribed {
+//!         mqtt.client.subscribe("topic", &[]).unwrap();
 //!         subscribed = true;
 //!     }
 //!
-//!     client.poll(|client, topic, message, properties| {
+//!     mqtt.poll(|client, topic, message, properties| {
 //!         match topic {
 //!             "topic" => {
 //!                println!("{:?}", message);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,35 +1,7 @@
 use minimq::{Minimq, Property, QoS};
 
 use embedded_nal::{self, IpAddr, Ipv4Addr};
-use embedded_time::{fraction::Fraction, Clock};
-use std::time::Instant;
-
-#[derive(Default)]
-struct StdClock {
-    start: core::cell::UnsafeCell<Option<Instant>>,
-}
-
-impl Clock for StdClock {
-    type T = u32;
-
-    const SCALING_FACTOR: Fraction = Fraction::new(1, 1_000);
-
-    fn try_now(&self) -> Result<embedded_time::Instant<Self>, embedded_time::clock::Error> {
-        let std_now = Instant::now();
-        let start = unsafe {
-            if (*self.start.get()).is_none() {
-                (*self.start.get()).replace(std_now);
-                std_now
-            } else {
-                (*self.start.get()).unwrap()
-            }
-        };
-
-        let elapsed = std_now - start;
-
-        Ok(embedded_time::Instant::new(elapsed.as_millis() as u32))
-    }
-}
+use std_embedded_time::StandardClock;
 
 #[test]
 fn main() -> std::io::Result<()> {
@@ -37,7 +9,7 @@ fn main() -> std::io::Result<()> {
 
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::<_, _, 256>::new(localhost, "", stack, StdClock::default()).unwrap();
+    let mut mqtt = Minimq::<_, _, 256>::new(localhost, "", stack, StandardClock::default()).unwrap();
 
     let mut published = false;
     let mut subscribed = false;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,7 +9,8 @@ fn main() -> std::io::Result<()> {
 
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::<_, _, 256>::new(localhost, "", stack, StandardClock::default()).unwrap();
+    let mut mqtt =
+        Minimq::<_, _, 256>::new(localhost, "", stack, StandardClock::default()).unwrap();
 
     let mut published = false;
     let mut subscribed = false;


### PR DESCRIPTION
This PR updates the tests to use `std-embedded-time` and updates the documentation in `lib.rs` to be compiled so that it doesn't become stale. It previously was broken.

This PR fixes #49 