### PR TITLE
Updating ping timeout to operate if no control packets are received

### DIFF
--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -376,6 +376,8 @@ where
     where
         F: FnMut(&mut MqttClient<N, C, T>, &'a str, &[u8], &[Property<'a>]),
     {
+        self.session_state.register_reception(self.clock.try_now()?);
+
         if !self.session_state.connected {
             if let ReceivedPacket::ConnAck(acknowledge) = packet {
                 let mut result = Ok(());


### PR DESCRIPTION
This PR fixes #53 by updating the ping timeout to operate if no control packets are received from the broker.

This is not required per the MQTT spec, but it should make the client more robust to disconnection events.

This PR also subtly fixes an issue with the ping timeout - previously, if no RX/TX was registered, a ping would never become due. This PR refactors the ping deadline logic to require a ping if there's no known last RX/TX time (when a deadline is set).