### PR TITLE
Feature/time refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ keep-alive interval
 * Fixing main docs.
 * Added support for publishing with QoS 1
 * Refactoring network stack management into a separate container class
+* Keep-alive settings now take a u16 integer number of seconds
 
 # Version 0.3.0
 Version 0.3.0 was published on 2021-08-06

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -13,7 +13,7 @@ const PING_TIMEOUT: Seconds = Seconds(5);
 
 pub struct SessionState<Clock: embedded_time::Clock, const MSG_SIZE: usize, const MSG_COUNT: usize>
 {
-    pub keep_alive_interval: Option<Milliseconds<u32>>,
+    keep_alive_interval: Option<Milliseconds<u32>>,
     ping_timeout: Option<Instant<Clock>>,
     next_ping: Option<Instant<Clock>>,
     pub broker: IpAddr,


### PR DESCRIPTION
This PR addresses some math concerns about the logic of the session state by instead storing the keep-alive interval in `Milliseconds`.

Additionally, the external API has been changed to accept only a u16 as the setting, as this is a restriction of MQTT anyways.