### PR TITLE
Adding support for will messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This document describes the changes to Minimq between releases.
 
 ## Added
 * Support for the `Will` message specification.
+* [breaking] Adding `retained` flag to `publish()` to allow messages to be published in a retained
+  manner.
 
 # Version 0.4.0
 Version 0.4.0 was published on 2021-10-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This document describes the changes to Minimq between releases.
 
 # Unreleased
 
+## Added
+* Support for the `Will` message specification.
+
 # Version 0.4.0
 Version 0.4.0 was published on 2021-10-08
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! temperature sensor installed.
 //!
 //! ```no_run
-//! use minimq::{Minimq, QoS};
+//! use minimq::{Minimq, QoS, Retain};
 //!
 //! // Construct an MQTT client with a maximum packet size of 256 bytes.
 //! // Connect to a broker at localhost - Use a client ID of "test".
@@ -51,7 +51,7 @@
 //!         match topic {
 //!             "topic" => {
 //!                println!("{:?}", message);
-//!                client.publish("echo", message, QoS::AtMostOnce, false, &[]).unwrap();
+//!                client.publish("echo", message, QoS::AtMostOnce, Retain::NotRetained, &[]).unwrap();
 //!             },
 //!             topic => println!("Unknown topic: {}", topic),
 //!         };
@@ -90,6 +90,16 @@ pub enum QoS {
 
     /// A packet will be delivered exactly one time.
     ExactlyOnce = 2,
+}
+
+/// The retained status for an MQTT message.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Retain {
+    /// The message shall not be retained by the broker.
+    NotRetained = 0,
+
+    /// The message shall be marked for retention by the broker.
+    Retained = 1,
 }
 
 /// Errors that are specific to the MQTT protocol implementation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!         match topic {
 //!             "topic" => {
 //!                println!("{:?}", message);
-//!                client.publish("echo", message, QoS::AtMostOnce, &[]).unwrap();
+//!                client.publish("echo", message, QoS::AtMostOnce, false, &[]).unwrap();
 //!             },
 //!             topic => println!("Unknown topic: {}", topic),
 //!         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,16 +67,30 @@ mod mqtt_client;
 mod network_manager;
 mod properties;
 mod session_state;
+mod will;
 
 use message_types::MessageType;
 pub use properties::Property;
 
 pub use embedded_nal;
 pub use embedded_time;
-pub use mqtt_client::{Minimq, QoS};
+pub use mqtt_client::Minimq;
 
 #[cfg(feature = "logging")]
 pub(crate) use log::{debug, error, info, warn};
+
+/// The quality-of-service for an MQTT message.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum QoS {
+    /// A packet will be delivered at most once, but may not be delivered at all.
+    AtMostOnce = 0,
+
+    /// A packet will be delivered at least one time, but possibly more than once.
+    AtLeastOnce = 1,
+
+    /// A packet will be delivered exactly one time.
+    ExactlyOnce = 2,
+}
 
 /// Errors that are specific to the MQTT protocol implementation.
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -268,6 +268,7 @@ where
         topic: &str,
         data: &[u8],
         qos: QoS,
+        retain: bool,
         properties: &[Property],
     ) -> Result<(), Error<TcpStack::Error>> {
         // TODO: QoS 2 support.
@@ -287,7 +288,8 @@ where
         let id = self.session_state.get_packet_identifier();
 
         let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
-        let packet = serialize::publish_message(&mut buffer, topic, data, qos, id, properties)?;
+        let packet =
+            serialize::publish_message(&mut buffer, topic, data, qos, retain, id, properties)?;
 
         self.network.write(packet)?;
         self.session_state.increment_packet_identifier();

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -137,7 +137,7 @@ where
     /// * `topic` - The topic to send the message on
     /// * `data` - The message to transmit
     /// * `qos` - The quality of service at which to send the message.
-    /// * `retained` - Specified true if the will message should be retained by the broker.
+    /// * `retained` - Specifies whether the will message should be retained by the broker.
     /// * `properties` - Any properties to send with the will message.
     pub fn set_will(
         &mut self,

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -148,7 +148,7 @@ where
         properties: &[Property],
     ) -> Result<(), Error<TcpStack::Error>> {
         let mut will = Will::new(topic, data, properties)?;
-        will.retained(retained == Retain::Retained);
+        will.retained(retained);
         will.qos(qos);
 
         self.will.replace(will);

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -288,15 +288,8 @@ where
         let id = self.session_state.get_packet_identifier();
 
         let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
-        let packet = serialize::publish_message(
-            &mut buffer,
-            topic,
-            data,
-            qos,
-            retain == Retain::Retained,
-            id,
-            properties,
-        )?;
+        let packet =
+            serialize::publish_message(&mut buffer, topic, data, qos, retain, id, properties)?;
 
         self.network.write(packet)?;
         self.session_state.increment_packet_identifier();

--- a/src/ser/packet_writer.rs
+++ b/src/ser/packet_writer.rs
@@ -173,7 +173,6 @@ impl<'a> ReversedPacketWriter<'a> {
         }
     }
 
-    #[cfg(test)]
     pub fn finish(self) -> &'a [u8] {
         &self.buffer[self.index..]
     }

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -1,7 +1,6 @@
-use crate::QoS;
 use crate::{
     message_types::MessageType, properties::PropertyIdentifier, ser::ReversedPacketWriter,
-    will::Will, Property, ProtocolError as Error,
+    will::Will, Property, ProtocolError as Error, QoS, Retain,
 };
 
 use bit_field::BitField;
@@ -58,7 +57,7 @@ pub fn connect_message<'a, const S: usize>(
         // the will message, and whether or not the will message should be retained.
         flags.set_bit(2, true);
         flags.set_bits(3..=4, will.qos as u8);
-        flags.set_bit(5, will.retain);
+        flags.set_bit(5, will.retain == Retain::Retained);
     }
 
     // Write the the client ID payload.
@@ -295,7 +294,7 @@ fn serialize_connect_with_will() {
     let client_id = "ABC".as_bytes();
     let mut will = Will::<100>::new("EFG", &[0xAB, 0xCD], &[]).unwrap();
     will.qos(QoS::AtMostOnce);
-    will.retained(false);
+    will.retained(Retain::NotRetained);
 
     let message = connect_message(&mut buffer, client_id, 10, &[], true, Some(&will)).unwrap();
 

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -1,7 +1,7 @@
 use crate::QoS;
 use crate::{
     message_types::MessageType, properties::PropertyIdentifier, ser::ReversedPacketWriter,
-    Property, ProtocolError as Error,
+    will::Will, Property, ProtocolError as Error,
 };
 
 use bit_field::BitField;
@@ -20,13 +20,14 @@ pub fn integer_size(value: usize) -> usize {
     }
 }
 
-pub fn connect_message<'a, 'b>(
-    dest: &'b mut [u8],
+pub fn connect_message<'a, const S: usize>(
+    dest: &'a mut [u8],
     client_id: &[u8],
     keep_alive: u16,
-    properties: &[Property<'a>],
+    properties: &[Property],
     clean_start: bool,
-) -> Result<&'b [u8], Error> {
+    will: Option<&Will<S>>,
+) -> Result<&'a [u8], Error> {
     // Validate the properties for this packet.
     for property in properties {
         match property.id() {
@@ -49,7 +50,18 @@ pub fn connect_message<'a, 'b>(
 
     let mut packet = ReversedPacketWriter::new(dest);
 
-    // Write the payload, which is the client ID.
+    if let Some(will) = will {
+        // Serialize the will data into the packet
+        packet.write(&will.payload)?;
+
+        // Update the flags for the will parameters. Indicate that the will is present, the QoS of
+        // the will message, and whether or not the will message should be retained.
+        flags.set_bit(2, true);
+        flags.set_bits(3..=4, will.qos as u8);
+        flags.set_bit(5, will.retain);
+    }
+
+    // Write the the client ID payload.
     packet.write_binary_data(client_id)?;
 
     // Write the variable header.
@@ -235,7 +247,46 @@ fn serialize_connect() {
 
     let mut buffer: [u8; 900] = [0; 900];
     let client_id = "ABC".as_bytes();
-    let message = connect_message(&mut buffer, client_id, 10, &[], true).unwrap();
+    let message = connect_message::<100>(&mut buffer, client_id, 10, &[], true, None).unwrap();
+
+    assert_eq!(message, good_serialized_connect)
+}
+
+#[test]
+fn serialize_connect_with_will() {
+    #[rustfmt::skip]
+    let good_serialized_connect: [u8; 28] = [
+        0x10, // Connect
+        26, // Remaining length
+
+        // Header: "MQTT5"
+        0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x05,
+
+        // Flags: Clean start, will present, will not retained, will QoS = 0,
+        0b0000_0110,
+
+        // Keep-alive: 10 seconds
+        0x00, 0x0a,
+
+        // Connected Properties: None
+        0x00,
+        // Client ID: "ABC"
+        0x00, 0x03, 0x41, 0x42, 0x43,
+        // Will properties: None
+        0x00,
+        // Will topic: "EFG"
+        0x00, 0x03, 0x45, 0x46, 0x47,
+        // Will payload: [0xAB, 0xCD]
+        0x00, 0x02, 0xAB, 0xCD,
+    ];
+
+    let mut buffer: [u8; 900] = [0; 900];
+    let client_id = "ABC".as_bytes();
+    let mut will = Will::<100>::new("EFG", &[0xAB, 0xCD], &[]).unwrap();
+    will.qos(QoS::AtMostOnce);
+    will.retained(false);
+
+    let message = connect_message(&mut buffer, client_id, 10, &[], true, Some(&will)).unwrap();
 
     assert_eq!(message, good_serialized_connect)
 }

--- a/src/will.rs
+++ b/src/will.rs
@@ -1,7 +1,7 @@
 use crate::{
     properties::{Property, PropertyIdentifier},
     ser::ReversedPacketWriter,
-    ProtocolError, QoS,
+    ProtocolError, QoS, Retain,
 };
 
 use heapless::Vec;
@@ -9,7 +9,7 @@ use heapless::Vec;
 pub struct Will<const MSG_SIZE: usize> {
     pub payload: Vec<u8, MSG_SIZE>,
     pub qos: QoS,
-    pub retain: bool,
+    pub retain: Retain,
 }
 
 impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
@@ -44,7 +44,7 @@ impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
 
         Ok(Self {
             qos: QoS::AtMostOnce,
-            retain: false,
+            retain: Retain::NotRetained,
             // Note(unwrap): The vectro is declared as identical size to the vector, so it will
             // always fit.
             payload: Vec::from_slice(packet.finish()).unwrap(),
@@ -55,7 +55,7 @@ impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
     ///
     /// # Args
     /// * `retained` - True if the will message should be retained by the broker.
-    pub fn retained(&mut self, retained: bool) {
+    pub fn retained(&mut self, retained: Retain) {
         self.retain = retained;
     }
 

--- a/src/will.rs
+++ b/src/will.rs
@@ -54,7 +54,7 @@ impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
     /// Set the retained status of the will.
     ///
     /// # Args
-    /// * `retained` - True if the will message should be retained by the broker.
+    /// * `retained` - Specifies the retained state of the will.
     pub fn retained(&mut self, retained: Retain) {
         self.retain = retained;
     }

--- a/src/will.rs
+++ b/src/will.rs
@@ -1,0 +1,69 @@
+use crate::{
+    properties::{Property, PropertyIdentifier},
+    ser::ReversedPacketWriter,
+    ProtocolError, QoS,
+};
+
+use heapless::Vec;
+
+pub struct Will<const MSG_SIZE: usize> {
+    pub payload: Vec<u8, MSG_SIZE>,
+    pub qos: QoS,
+    pub retain: bool,
+}
+
+impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
+    /// Construct a new will message.
+    ///
+    /// # Args
+    /// * `topic` - The topic to send the message on
+    /// * `data` - The message to transmit
+    /// * `properties` - Any properties to send with the will message.
+    pub fn new(topic: &str, data: &[u8], properties: &[Property]) -> Result<Self, ProtocolError> {
+        // Check that the input properties are valid for a will.
+        for property in properties {
+            match property.id() {
+                PropertyIdentifier::WillDelayInterval
+                | PropertyIdentifier::PayloadFormatIndicator
+                | PropertyIdentifier::MessageExpiryInterval
+                | PropertyIdentifier::ContentType
+                | PropertyIdentifier::ResponseTopic
+                | PropertyIdentifier::CorrelationData
+                | PropertyIdentifier::UserProperty => {}
+                _ => return Err(ProtocolError::InvalidProperty),
+            }
+        }
+
+        let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
+        let mut packet = ReversedPacketWriter::new(&mut buffer);
+
+        // Serialize the will payload
+        packet.write_binary_data(data)?;
+        packet.write_utf8_string(topic)?;
+        packet.write_properties(properties)?;
+
+        Ok(Self {
+            qos: QoS::AtMostOnce,
+            retain: false,
+            // Note(unwrap): The vectro is declared as identical size to the vector, so it will
+            // always fit.
+            payload: Vec::from_slice(packet.finish()).unwrap(),
+        })
+    }
+
+    /// Set the retained status of the will.
+    ///
+    /// # Args
+    /// * `retained` - True if the will message should be retained by the broker.
+    pub fn retained(&mut self, retained: bool) {
+        self.retain = retained;
+    }
+
+    /// Set the quality of service at which the will message is sent.
+    ///
+    /// # Args
+    /// * `qos` - The desired quality-of-service level to send the message at.
+    pub fn qos(&mut self, qos: QoS) {
+        self.qos = qos;
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use minimq::{Minimq, Property, QoS};
+use minimq::{Minimq, Property, QoS, Retain};
 
 use embedded_nal::{self, IpAddr, Ipv4Addr};
 use std_embedded_time::StandardClock;
@@ -21,7 +21,7 @@ fn main() -> std::io::Result<()> {
             "exit",
             "Test complete".as_bytes(),
             QoS::AtMostOnce,
-            false,
+            Retain::NotRetained,
             &[],
         )
         .unwrap();
@@ -33,7 +33,13 @@ fn main() -> std::io::Result<()> {
             for property in properties {
                 if let Property::ResponseTopic(topic) = property {
                     client
-                        .publish(topic, "Pong".as_bytes(), QoS::AtMostOnce, false, &[])
+                        .publish(
+                            topic,
+                            "Pong".as_bytes(),
+                            QoS::AtMostOnce,
+                            Retain::NotRetained,
+                            &[],
+                        )
                         .unwrap();
                 }
             }
@@ -64,7 +70,7 @@ fn main() -> std::io::Result<()> {
                             "request",
                             "Ping".as_bytes(),
                             QoS::AtMostOnce,
-                            false,
+                            Retain::NotRetained,
                             &properties,
                         )
                         .unwrap();
@@ -74,7 +80,7 @@ fn main() -> std::io::Result<()> {
                             "request",
                             "Ping".as_bytes(),
                             QoS::AtLeastOnce,
-                            false,
+                            Retain::NotRetained,
                             &properties,
                         )
                         .unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -33,7 +33,7 @@ fn main() -> std::io::Result<()> {
             for property in properties {
                 if let Property::ResponseTopic(topic) = property {
                     client
-                        .publish(topic, "Pong".as_bytes(), QoS::AtMostOnce, &[])
+                        .publish(topic, "Pong".as_bytes(), QoS::AtMostOnce, false, &[])
                         .unwrap();
                 }
             }
@@ -60,11 +60,23 @@ fn main() -> std::io::Result<()> {
                     println!("PUBLISH request");
                     let properties = [Property::ResponseTopic("response")];
                     mqtt.client
-                        .publish("request", "Ping".as_bytes(), QoS::AtMostOnce, &properties)
+                        .publish(
+                            "request",
+                            "Ping".as_bytes(),
+                            QoS::AtMostOnce,
+                            false,
+                            &properties,
+                        )
                         .unwrap();
 
                     mqtt.client
-                        .publish("request", "Ping".as_bytes(), QoS::AtLeastOnce, &properties)
+                        .publish(
+                            "request",
+                            "Ping".as_bytes(),
+                            QoS::AtLeastOnce,
+                            false,
+                            &properties,
+                        )
                         .unwrap();
 
                     // The message cannot be ack'd until the next poll call

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,6 +16,16 @@ fn main() -> std::io::Result<()> {
     let mut subscribed = false;
     let mut responses = 0;
 
+    mqtt.client
+        .set_will(
+            "exit",
+            "Test complete".as_bytes(),
+            QoS::AtMostOnce,
+            false,
+            &[],
+        )
+        .unwrap();
+
     loop {
         mqtt.poll(|client, topic, payload, properties| {
             println!("{} < {}", topic, core::str::from_utf8(payload).unwrap());


### PR DESCRIPTION
This PR adds support for sending a `Will` message in the connection request to the broker.

The will is a message that will be published whenever the client disconnects without explicitly sending a `Disconnect` message.

This can be used to allow the broker to report, for example, the connection state of a client.