### PR TITLE
Implement finishing partial writes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ pub enum ProtocolError {
 pub enum Error<E> {
     Network(E),
     WriteFail,
+    PartialWrite,
     NotReady,
     Unsupported,
     ProvidedClientIdTooLong,

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -68,7 +68,7 @@ pub struct MqttClient<
     const MSG_SIZE: usize,
     const MSG_COUNT: usize,
 > {
-    pub(crate) network: InterfaceHolder<TcpStack>,
+    pub(crate) network: InterfaceHolder<TcpStack, MSG_SIZE>,
     clock: Clock,
     session_state: SessionState<Clock, MSG_SIZE, MSG_COUNT>,
     connection_state: StateMachine<Context>,
@@ -283,6 +283,16 @@ where
         }
 
         Ok(())
+    }
+
+    /// Finish sending last packet if the previous operation returned Error::PartialWrite
+    ///
+    /// # Note
+    /// If this function is not called after partial write until the packet is
+    /// fully sent, the packets will most likely seem malformed to the receiving
+    /// party and they will close the connection.
+    pub fn finish_write(&mut self) -> Result<(), Error<TcpStack::Error>> {
+        self.network.finish_write()
     }
 
     fn handle_connection_acknowledge(


### PR DESCRIPTION
I've been running into issues with getting RST packets from brokers fairly often if there was high load. This is painful especially because starting the connection takes really long time for some reason. It turns out my TCP stack just couldn't keep up and in the current implementation the `WriteFail` error is returned if the write would either block or if it was partially written. The latter usually breaks the MQTT connection because there is currently no way to finish the packet send.

The issue is with the partial writes which usually contained the header including length of the MQTT message but only the first half was actually transferred, the rest was silently dropped. On a subsequent write the first half of the next packet would be interpreted by the broker as the second half of the preceding packet and the rest as a new MQTT packet, which usually turned out to be malformed so the broker sent a disconnect packet and after some time closed the TCP connection.

This solution is fairly simple although it eats up a bit more space (because the network manager must be able to store up to a full packet). I wasn't very successful with convincing the borrow checker that what I want to do is safe so the unfinished packet ends up being copied once after the unsuccessful send and once when we want to try to finish.