### PR TITLE
Patching keepalive interval support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ This document describes the changes to Minimq between releases.
 # [Unreleased]
 
 ## Added
-## Removed
-## Changed
+## Fixed
+
+# Version [0.5.1]
+Version 0.5.1 was published on 2021-12-07
+
+## Fixed
+* Fixed an issue where the keepalive interval could not be set properly. See
+  [#69](https://github.com/quartiq/minimq/issues/69).
 
 # Version [0.5.0]
 Version 0.5.0 was published on 2021-12-06
@@ -59,7 +65,8 @@ Version 0.1.0 was published on 2020-08-27
 
 * Initial library release and publish to crates.io
 
-[Unreleased]: https://github.com/quartiq/minimq/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/quartiq/minimq/compare/0.5.1...HEAD
+[0.5.0]: https://github.com/quartiq/minimq/releases/tag/0.5.1
 [0.5.0]: https://github.com/quartiq/minimq/releases/tag/0.5.0
 [0.4.0]: https://github.com/quartiq/minimq/releases/tag/0.4.0
 [0.3.0]: https://github.com/quartiq/minimq/releases/tag/0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Version 0.5.1 was published on 2021-12-07
 ## Fixed
 * Fixed an issue where the keepalive interval could not be set properly. See
   [#69](https://github.com/quartiq/minimq/issues/69).
+* Fixed an issue where the keepalive interval was not set properly. See
+  [#70](https://github.com/quartiq/minimq/issues/70).
 
 # Version [0.5.0]
 Version 0.5.0 was published on 2021-12-06

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimq"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>", "Max Rottenkolber <max@mr.gy>"]
 edition = "2018"
 

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -175,7 +175,9 @@ where
         &mut self,
         interval_seconds: u16,
     ) -> Result<(), Error<TcpStack::Error>> {
-        if self.connection_state.state() != &States::Active {
+        if (self.connection_state.state() == &States::Active)
+            || (self.connection_state.state() == &States::Establishing)
+        {
             return Err(Error::NotReady);
         }
 

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -60,7 +60,7 @@ impl<Clock: embedded_time::Clock, const MSG_SIZE: usize, const MSG_COUNT: usize>
     /// # Note
     /// If no keep-alive interval is specified, zero is returned.
     pub fn keepalive_interval(&self) -> u16 {
-        (self.keep_alive_interval.unwrap_or(0.milliseconds()).0 * 1000) as u16
+        (self.keep_alive_interval.unwrap_or(0.milliseconds()).0 / 1000) as u16
     }
 
     /// Update the keep-alive interval.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,6 +12,9 @@ fn main() -> std::io::Result<()> {
     let mut mqtt =
         Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
 
+    // Use a keepalive interval for the client.
+    mqtt.client.set_keepalive_interval(60).unwrap();
+
     let mut published = false;
     let mut subscribed = false;
     let mut responses = 0;


### PR DESCRIPTION
This PR fixes #69 by adjusting state management that is used to determine when keepalive intervals may be configured.

This PR also fixes #70 by properly dividing by 1000 instead of multiplying when retrieving the keepalive.

I applied this patch to an active stabilizer, waited for `alive` topics to be published by `miniconf`, and then disconnected ethernet. After 2.5 minutes the `alive` topic will properly indicated that the device was no longer connected.