### PR TITLE
Correcting documentation generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This document describes the changes to Minimq between releases.
 
 ## Added
 ## Fixed
+* Made `mqtt_client` module public to correct documentation
 
 # Version [0.5.1]
 Version 0.5.1 was published on 2021-12-07

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub(crate) mod de;
 pub(crate) mod ser;
 
 mod message_types;
-mod mqtt_client;
+pub mod mqtt_client;
 mod network_manager;
 mod properties;
 mod session_state;


### PR DESCRIPTION
This PR fixes #72 by making the `mqtt_client` module public.

(thanks @systec-ms!)