### PR TITLE
Handling partial MQTT packet writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This document describes the changes to Minimq between releases.
 
 ## Added
 ## Fixed
+* Partial packet writes no longer cause the connection to the broker to break down.
+  [#74](https://github.com/quartiq/minimq/issues/74)
 
 # Version [0.5.1]
 Version 0.5.1 was published on 2021-12-07

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,6 @@ pub enum ProtocolError {
 pub enum Error<E> {
     Network(E),
     WriteFail,
-    PartialWrite,
     NotReady,
     Unsupported,
     ProvidedClientIdTooLong,

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -5,7 +5,6 @@
 //! simple ownership semantics of reading and writing to the network stack. This allows the network
 //! stack to be used to transmit buffers that may be stored internally in other structs without
 //! violating Rust's borrow rules.
-
 use embedded_nal::{nb, SocketAddr, TcpClientStack};
 use heapless::Vec;
 


### PR DESCRIPTION
This PR fixes #74 by incorporating changes from #68 with additional safeguards.

Specifically, any attempt to write a packet is now safe guarded by checking that packet writes are acceptable. It's invalid to attempt to send a packet while a partial packet is still being transmitted, as this would corrupt the MQTT connection.

CC @mladedav 