### PR TITLE
Deriving PartialEq for properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This document describes the changes to Minimq between releases.
 # [Unreleased]
 
 ## Added
+* Property comparison now implements PartialEq
+
 ## Fixed
 
 # [0.5.2] - 2021-12-14

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use enum_iterator::IntoEnumIterator;
 
-#[derive(Copy, Clone, IntoEnumIterator)]
+#[derive(Copy, Clone, PartialEq, IntoEnumIterator)]
 pub(crate) enum PropertyIdentifier {
     Invalid = -1,
 
@@ -47,7 +47,7 @@ pub(crate) enum PropertyIdentifier {
 }
 
 /// All of the possible properties that MQTT version 5 supports.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Property<'a> {
     PayloadFormatIndicator(u8),
     MessageExpiryInterval(u32),


### PR DESCRIPTION
This PR fixes the `Property` enum to derive PartialEq to allow easy comparison of properties. This is useful e.g. for comparing CorrelationData.