### PR TITLE
Adding `ReceiveMaximum` property to connection requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document describes the changes to Minimq between releases.
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`
 
 ## Fixed
+* The `ReceiveMaximum` property is now sent in the connection request to the broker
 
 # [0.5.3] - 2022-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This document describes the changes to Minimq between releases.
 ## Added
 * Allow configuration of non-default broker port numbers
 
+## Changed
+* [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`
+
 ## Fixed
 
 # [0.5.3] - 2022-02-14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,11 @@ bit_field = "0.10.0"
 enum-iterator = "0.6.0"
 heapless = "0.7"
 log = {version = "0.4", optional = true}
-smlang = "0.4"
 embedded-time = "0.12"
+
+[dependencies.smlang]
+git = "https://github.com/ryan-summers/smlang-rs"
+branch = "feature/versatile-guard-errors"
 
 [dependencies.embedded-nal]
 version = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@
 //! let mut subscribed = false;
 //!
 //! loop {
-//!     if mqtt.client.is_connected() && !subscribed {
-//!         mqtt.client.subscribe("topic", &[]).unwrap();
+//!     if mqtt.client().is_connected() && !subscribed {
+//!         mqtt.client().subscribe("topic", &[]).unwrap();
 //!         subscribed = true;
 //!     }
 //!

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -68,6 +68,7 @@ where
             Property::MaximumPacketSize(MSG_SIZE as u32),
             // The session does not expire.
             Property::SessionExpiryInterval(u32::MAX),
+            Property::ReceiveMaximum(MSG_COUNT as u16),
         ];
 
         let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -137,7 +137,7 @@ impl<Clock: embedded_time::Clock, const MSG_SIZE: usize, const MSG_COUNT: usize>
         self.active
     }
 
-    pub fn get_packet_identifier(&mut self) -> u16 {
+    pub fn get_packet_identifier(&self) -> u16 {
         self.packet_id
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,7 +6,6 @@ use std_embedded_time::StandardClock;
 #[test]
 fn main() -> std::io::Result<()> {
     env_logger::init();
-    log::info!("Starting test");
 
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));


### PR DESCRIPTION
This PR fixes #65 by reporting the `ReceiveMaximum` in the connection request to the broker.

This should be merged after https://github.com/quartiq/minimq/pull/88.