### PR TITLE
Implementing robust QoS retransmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This document describes the changes to Minimq between releases.
 * Allow configuration of non-default broker port numbers
 
 ## Fixed
+* All unacknowledged messages will be guaranteed to be retransmitted upon connection with the
+broker.
 
 # [0.5.3] - 2022-02-14
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,8 @@ pub enum ProtocolError {
     UnsupportedPacket,
     BufferSize,
     InvalidProperty,
+    BadIdentifier,
+    WrongQos,
 }
 
 /// Possible errors encountered during an MQTT connection.

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -434,7 +434,12 @@ impl<
         }
 
         while !self.network.has_pending_write() {
-            if let Some(msg) = self.sm.context_mut().session_state.next_pending_republication() {
+            if let Some(msg) = self
+                .sm
+                .context_mut()
+                .session_state
+                .next_pending_republication()
+            {
                 self.network.write(msg)?;
             } else {
                 break;
@@ -568,9 +573,7 @@ impl<
 
         let minimq = Minimq {
             client: MqttClient {
-                sm: StateMachine::new(ClientContext {
-                    session_state,
-                }),
+                sm: StateMachine::new(ClientContext { session_state }),
                 broker: SocketAddr::new(broker, MQTT_INSECURE_DEFAULT_PORT),
                 will: None,
                 network: InterfaceHolder::new(network_stack),

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -429,7 +429,7 @@ where
 
             ReceivedPacket::PubAck(ack) => {
                 // No matter the status code the message is considered acknowledged at this point
-                self.session_state.handle_puback(ack.packet_identifier);
+                self.session_state.handle_puback(ack.packet_identifier)?;
 
                 Ok(())
             }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -389,15 +389,6 @@ where
         self.session_state
             .register_connection(self.clock.try_now()?);
 
-        // Replay QoS messages
-        while !self.network.has_pending_write() {
-            if let Some(msg) = self.session_state.next_pending_republication() {
-                self.network.write(msg)?;
-            } else {
-                break;
-            }
-        }
-
         result
     }
 

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -16,7 +16,6 @@ const PING_TIMEOUT: Seconds = Seconds(5);
 pub struct MessageRecord<const N: usize> {
     pub msg: Vec<u8, N>,
     transmitted: bool,
-    _id: u16,
     qos: QoS,
 }
 
@@ -105,14 +104,13 @@ impl<
         id: u16,
         packet: &[u8],
     ) -> Result<(), Error<TcpStack::Error>> {
-        let mut buf: Vec<u8, MSG_SIZE> = Vec::from_slice(packet).unwrap();
+        let mut msg: Vec<u8, MSG_SIZE> = Vec::from_slice(packet).unwrap();
         // Set DUP = 1 (bit 3). If this packet is ever read it's just because we want to resend it
-        buf[0] |= 1 << 3;
+        msg[0] |= 1 << 3;
 
         let record = MessageRecord {
-            _id: id,
             qos,
-            msg: buf,
+            msg,
             transmitted: true,
         };
 

--- a/src/session_state.rs
+++ b/src/session_state.rs
@@ -178,6 +178,12 @@ impl<
         if let Some(interval) = self.keep_alive_interval {
             self.next_ping.replace(now + interval / 2);
         }
+
+        // We just reconnected to the broker. Any of our pending publications will need to be
+        // republished.
+        for (_key, value) in self.pending_publish.iter_mut() {
+            value.transmitted = false;
+        }
     }
 
     /// Indicates if there is present session state available.


### PR DESCRIPTION
This PR fixes #59 by guaranteeing that all QoS retransmissions will be properly republished upon reconnecting to the broker.