### PR TITLE
Adding `Qos::ExactlyOnce` transmission support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ broker.
 
 ## Added
 * Property comparison now implements PartialEq
+* Support added for QoS::ExactlyOnce transmission
 
 # [0.5.2] - 2021-12-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ default = []
 logging = ["log"]
 
 [dev-dependencies]
+log = "0.4"
 env_logger = "0.7"
 std-embedded-nal = "0.1"
 std-embedded-time = "0.1"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ publication. Below is a detailed list of features, indicating what aspects are s
 aren't:
 * Will messages are fully supported.
 * Message subscription is fully supported.
-* Message publication is currently only supported for the following quality-of-service (QoS) levels:
-    1. At Most Once (Level 0)
-    2. At Least Once (Level 1)
+* Message publication is supported for all quality-of-service (QoS) levels
 * Message reception is only supported for the following QoS levels:
     1. At Most once (Level 0)
 

--- a/src/de/deserialize.rs
+++ b/src/de/deserialize.rs
@@ -75,6 +75,15 @@ pub struct PubComp<'a> {
 }
 
 #[derive(Debug)]
+pub struct Disconnect<'a> {
+    /// The success status of the disconnection.
+    pub reason_code: u8,
+
+    /// Properties associated with the disconnection.
+    pub properties: Vec<Property<'a>, 8>,
+}
+
+#[derive(Debug)]
 pub enum ReceivedPacket<'a> {
     ConnAck(ConnAck<'a>),
     Publish(Pub<'a>),
@@ -82,6 +91,7 @@ pub enum ReceivedPacket<'a> {
     SubAck(SubAck<'a>),
     PubRec(PubRec<'a>),
     PubComp(PubComp<'a>),
+    Disconnect(Disconnect<'a>),
     PingResp,
 }
 
@@ -134,6 +144,9 @@ impl<'a> ReceivedPacket<'a> {
 
             MessageType::PubRec => Ok(ReceivedPacket::PubRec(parse_pubrec(packet_reader)?)),
             MessageType::PubComp => Ok(ReceivedPacket::PubComp(parse_pubcomp(packet_reader)?)),
+            MessageType::Disconnect => {
+                Ok(ReceivedPacket::Disconnect(parse_disconnect(packet_reader)?))
+            }
 
             _ => Err(Error::UnsupportedPacket),
         }
@@ -224,7 +237,14 @@ fn parse_pubrec<const T: usize>(p: &PacketReader<T>) -> Result<PubRec, Error> {
     let id = p.read_u16()?;
 
     // Reason code and properties are both optionally present.
-    // TODO: Handle cases when these are not present gracefully.
+    if p.remaining_len()? == 0 {
+        return Ok(PubRec {
+            packet_id: id,
+            reason_code: 0,
+            properties: Vec::new(),
+        });
+    }
+
     let reason_code = p.read_u8()?;
     let properties = p.read_properties()?;
 
@@ -239,12 +259,28 @@ fn parse_pubcomp<const T: usize>(p: &PacketReader<T>) -> Result<PubComp, Error> 
     let id = p.read_u16()?;
 
     // Reason code and properties are both optionally present.
-    // TODO: Handle cases when these are not present gracefully.
+    if p.remaining_len()? == 0 {
+        return Ok(PubComp {
+            packet_id: id,
+            reason_code: 0,
+            properties: Vec::new(),
+        });
+    }
+
     let reason_code = p.read_u8()?;
     let properties = p.read_properties()?;
 
     Ok(PubComp {
         packet_id: id,
+        reason_code,
+        properties,
+    })
+}
+
+fn parse_disconnect<const T: usize>(p: &PacketReader<T>) -> Result<Disconnect, Error> {
+    let reason_code = p.read_u8()?;
+    let properties = p.read_properties()?;
+    Ok(Disconnect {
         reason_code,
         properties,
     })
@@ -377,8 +413,9 @@ mod test {
     fn deserialize_good_pubcomp() {
         let mut serialized_pubcomp: [u8; 6] = [
             7 << 4, // PubComp
-            0x04, // Remaining length
-            0x00, 0x05, // Identifier
+            0x04,   // Remaining length
+            0x00,
+            0x05, // Identifier
             0x16, // Response Code
             0x00, // Properties length
         ];
@@ -395,11 +432,32 @@ mod test {
     }
 
     #[test]
+    fn deserialize_short_pubcomp() {
+        let mut serialized_pubcomp: [u8; 4] = [
+            7 << 4, // PubComp
+            0x02,   // Remaining length
+            0x00,
+            0x05, // Identifier
+        ];
+        let mut reader = PacketReader::<32>::from_serialized(&mut serialized_pubcomp);
+        let pub_comp = ReceivedPacket::parse_message(&mut reader).unwrap();
+        match pub_comp {
+            ReceivedPacket::PubComp(comp) => {
+                assert_eq!(comp.packet_id, 5);
+                assert_eq!(comp.reason_code, 0);
+                assert_eq!(comp.properties.len(), 0);
+            }
+            _ => panic!("Invalid message"),
+        }
+    }
+
+    #[test]
     fn deserialize_good_pubrec() {
         let mut serialized_pubrec: [u8; 6] = [
             5 << 4, // PubRec
-            0x04, // Remaining length
-            0x00, 0x05, // Identifier
+            0x04,   // Remaining length
+            0x00,
+            0x05, // Identifier
             0x10, // Response Code
             0x00, // Properties length
         ];
@@ -409,6 +467,26 @@ mod test {
             ReceivedPacket::PubRec(rec) => {
                 assert_eq!(rec.packet_id, 5);
                 assert_eq!(rec.reason_code, 0x10);
+                assert_eq!(rec.properties.len(), 0);
+            }
+            _ => panic!("Invalid message"),
+        }
+    }
+
+    #[test]
+    fn deserialize_short_pubrec() {
+        let mut serialized_pubrec: [u8; 4] = [
+            5 << 4, // PubRec
+            0x02,   // Remaining length
+            0x00,
+            0x05, // Identifier
+        ];
+        let mut reader = PacketReader::<32>::from_serialized(&mut serialized_pubrec);
+        let pub_rec = ReceivedPacket::parse_message(&mut reader).unwrap();
+        match pub_rec {
+            ReceivedPacket::PubRec(rec) => {
+                assert_eq!(rec.packet_id, 5);
+                assert_eq!(rec.reason_code, 0);
                 assert_eq!(rec.properties.len(), 0);
             }
             _ => panic!("Invalid message"),

--- a/src/de/deserialize.rs
+++ b/src/de/deserialize.rs
@@ -372,4 +372,46 @@ mod test {
             _ => panic!("Invalid message"),
         }
     }
+
+    #[test]
+    fn deserialize_good_pubcomp() {
+        let mut serialized_pubcomp: [u8; 6] = [
+            7 << 4, // PubComp
+            0x04, // Remaining length
+            0x00, 0x05, // Identifier
+            0x16, // Response Code
+            0x00, // Properties length
+        ];
+        let mut reader = PacketReader::<32>::from_serialized(&mut serialized_pubcomp);
+        let pub_comp = ReceivedPacket::parse_message(&mut reader).unwrap();
+        match pub_comp {
+            ReceivedPacket::PubComp(comp) => {
+                assert_eq!(comp.packet_id, 5);
+                assert_eq!(comp.reason_code, 0x16);
+                assert_eq!(comp.properties.len(), 0);
+            }
+            _ => panic!("Invalid message"),
+        }
+    }
+
+    #[test]
+    fn deserialize_good_pubrec() {
+        let mut serialized_pubrec: [u8; 6] = [
+            5 << 4, // PubRec
+            0x04, // Remaining length
+            0x00, 0x05, // Identifier
+            0x10, // Response Code
+            0x00, // Properties length
+        ];
+        let mut reader = PacketReader::<32>::from_serialized(&mut serialized_pubrec);
+        let pub_rec = ReceivedPacket::parse_message(&mut reader).unwrap();
+        match pub_rec {
+            ReceivedPacket::PubRec(rec) => {
+                assert_eq!(rec.packet_id, 5);
+                assert_eq!(rec.reason_code, 0x10);
+                assert_eq!(rec.properties.len(), 0);
+            }
+            _ => panic!("Invalid message"),
+        }
+    }
 }

--- a/src/de/packet_reader.rs
+++ b/src/de/packet_reader.rs
@@ -73,6 +73,10 @@ impl<const T: usize> PacketReader<T> {
         Ok(borrowed_data)
     }
 
+    pub fn remaining_len(&self) -> Result<usize, Error> {
+        Ok(self.packet_length()? - *self.index.borrow())
+    }
+
     pub fn len(&self) -> Result<usize, Error> {
         Ok(self.packet_length()? - *self.index.borrow())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use embedded_time;
 pub use mqtt_client::Minimq;
 
 #[cfg(feature = "logging")]
-pub(crate) use log::{debug, error, info, warn};
+pub(crate) use log::{debug, error, info, trace, warn};
 
 /// Default port number for unencrypted MQTT traffic
 ///
@@ -163,6 +163,14 @@ impl<E> From<ProtocolError> for Error<E> {
 #[doc(hidden)]
 #[cfg(not(feature = "logging"))]
 mod mqtt_log {
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! trace {
+        ($($arg:tt)+) => {
+            ()
+        };
+    }
+
     #[doc(hidden)]
     #[macro_export]
     macro_rules! debug {

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -334,7 +334,7 @@ where
         self.network.write(packet)?;
         self.session_state.increment_packet_identifier();
 
-        if qos == QoS::AtLeastOnce {
+        if qos != QoS::AtMostOnce {
             self.session_state.handle_publish(qos, id, packet)?;
         }
 
@@ -467,6 +467,7 @@ where
 
                 // Send the pub-rel packet.
                 let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
+                info!("Sending PubRel({})", rec.packet_id);
                 let packet = serialize::pubrel_message(&mut buffer, rec.packet_id, 0, &[])?;
                 self.network.write(packet)?;
                 Ok(())

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -461,6 +461,22 @@ where
                 Ok(())
             }
 
+            ReceivedPacket::PubRec(rec) => {
+                // TODO: Utilize errors to generate reason codes.
+                self.session_state.handle_pubrec(rec.packet_id)?;
+
+                // Send the pub-rel packet.
+                let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
+                let packet = serialize::pubrel_message(&mut buffer, rec.packet_id, 0, &[])?;
+                self.network.write(packet)?;
+                Ok(())
+            }
+
+            ReceivedPacket::PubComp(comp) => {
+                self.session_state.handle_pubcomp(comp.packet_id)?;
+                Ok(())
+            }
+
             _ => Err(Error::Unsupported),
         }
     }

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -128,8 +128,10 @@ where
         let socket = self.socket.as_mut().ok_or(Error::NotReady)?;
         let result = self.network_stack.receive(socket, buf);
 
+        #[cfg(features = "logging")]
         if let Ok(len) = result {
-            crate::trace!("Read: {:0x?}", &buf[..len]);
+            let data = &buf[..len];
+            crate::trace!("Read: {:0x?}", data);
         }
 
         result.or_else(|err| match err {

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -98,6 +98,7 @@ where
                 nb::Error::Other(err) => Err(Error::Network(err)),
             })
             .map(|written| {
+                crate::trace!("Wrote: {:0x?}", &data[..written]);
                 if written != data.len() {
                     // Note(unwrap): The packet should always be smaller than a single message.
                     self.pending_write
@@ -126,6 +127,10 @@ where
         // Atomically access the socket.
         let socket = self.socket.as_mut().ok_or(Error::NotReady)?;
         let result = self.network_stack.receive(socket, buf);
+
+        if let Ok(len) = result {
+            crate::trace!("Read: {:0x?}", &buf[..len]);
+        }
 
         result.or_else(|err| match err {
             nb::Error::WouldBlock => Ok(0),

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -334,3 +334,17 @@ fn serialize_ping_req() {
     let mut buffer: [u8; 1024] = [0; 1024];
     assert_eq!(ping_req_message(&mut buffer).unwrap(), good_ping_req);
 }
+
+#[test]
+fn serialize_pubrel() {
+    let good_pubrel: [u8; 6] = [
+        6 << 4, // PubRec
+        0x04, // Remaining length
+        0x00, 0x05, // Identifier
+        0x10, // Response Code
+        0x00, // Properties length
+    ];
+
+    let mut buffer: [u8; 1024] = [0; 1024];
+    assert_eq!(pubrel_message(&mut buffer, 5, 0x10, &[]).unwrap(), good_pubrel);
+}

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -156,6 +156,19 @@ pub fn subscribe_message<'a, 'b, 'c>(
     packet.finalize(MessageType::Subscribe, 0b0010)
 }
 
+pub fn pubrel_message<'c, 'a>(
+    dest: &'c mut [u8],
+    packet_id: u16,
+    reason: u8,
+    properties: &[Property<'a>],
+) -> Result<&'c [u8], Error> {
+    let mut packet = ReversedPacketWriter::new(dest);
+    packet.write_properties(properties)?;
+    packet.write(&[reason])?;
+    packet.write_u16(packet_id)?;
+    packet.finalize(MessageType::PubRel, 0)
+}
+
 #[test]
 pub fn serialize_publish() {
     let good_publish: [u8; 10] = [

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -21,7 +21,8 @@ fn main() -> std::io::Result<()> {
         mqtt.poll(|_client, _topic, _payload, _properties| {})
             .unwrap();
 
-        if mqtt.client().is_connected() && !published && mqtt.client().can_publish(QoS::ExactlyOnce) {
+        if mqtt.client().is_connected() && !published && mqtt.client().can_publish(QoS::ExactlyOnce)
+        {
             mqtt.client()
                 .publish(
                     "data",

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -1,0 +1,43 @@
+use minimq::{Minimq, QoS, Retain};
+
+use embedded_nal::{self, IpAddr, Ipv4Addr};
+use std_embedded_time::StandardClock;
+
+#[test]
+fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    let stack = std_embedded_nal::Stack::default();
+    let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let mut mqtt =
+        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+
+    // Use a keepalive interval for the client.
+    mqtt.client.set_keepalive_interval(60).unwrap();
+
+    let mut published = false;
+
+    loop {
+        mqtt.poll(|_client, _topic, _payload, _properties| {})
+            .unwrap();
+
+        if mqtt.client.is_connected() && !published && mqtt.client.can_publish(QoS::ExactlyOnce) {
+            mqtt.client
+                .publish(
+                    "data",
+                    "Ping".as_bytes(),
+                    QoS::ExactlyOnce,
+                    Retain::NotRetained,
+                    &[],
+                )
+                .unwrap();
+            log::info!("Publishing message");
+            published = true;
+        }
+
+        if published && mqtt.client.pending_messages(QoS::ExactlyOnce) == 0 {
+            log::info!("Transmission complete");
+            std::process::exit(0);
+        }
+    }
+}

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -13,7 +13,7 @@ fn main() -> std::io::Result<()> {
         Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
 
     // Use a keepalive interval for the client.
-    mqtt.client.set_keepalive_interval(60).unwrap();
+    mqtt.client().set_keepalive_interval(60).unwrap();
 
     let mut published = false;
 
@@ -21,8 +21,8 @@ fn main() -> std::io::Result<()> {
         mqtt.poll(|_client, _topic, _payload, _properties| {})
             .unwrap();
 
-        if mqtt.client.is_connected() && !published && mqtt.client.can_publish(QoS::ExactlyOnce) {
-            mqtt.client
+        if mqtt.client().is_connected() && !published && mqtt.client().can_publish(QoS::ExactlyOnce) {
+            mqtt.client()
                 .publish(
                     "data",
                     "Ping".as_bytes(),
@@ -35,7 +35,7 @@ fn main() -> std::io::Result<()> {
             published = true;
         }
 
-        if published && mqtt.client.pending_messages(QoS::ExactlyOnce) == 0 {
+        if published && mqtt.client().pending_messages(QoS::ExactlyOnce) == 0 {
             log::info!("Transmission complete");
             std::process::exit(0);
         }


### PR DESCRIPTION
This PR adds support for the `QoS::ExactlyOnce` transmission mechanism.

This PR fixes #60 

This PR builds on #90 

TODO:
- [x] Determine an integration test for exactly once transmission