### PR TITLE
Updating parsing to avoid copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document describes the changes to Minimq between releases.
 
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`
+* Single MQTT packets are now processed per `Minimq::poll()` execution, reducing stack usage.
 
 ## Fixed
 * All unacknowledged messages will be guaranteed to be retransmitted upon connection with the

--- a/src/de/deserialize.rs
+++ b/src/de/deserialize.rs
@@ -98,14 +98,14 @@ pub enum ReceivedPacket<'a> {
 }
 
 impl<'a> ReceivedPacket<'a> {
-    /// Parse a message out of a `PacketParser` into a validated MQTT control message.
+    /// Parse a validated MQTT control packet out of a `PacketParser`.
     ///
     /// # Args
     /// * `packet_reader` - The reader to parse the message out of.
     ///
     /// # Returns
     /// A packet describing the received content.
-    pub(crate) fn parse_message<'reader: 'a>(
+    pub(crate) fn parse_packet<'reader: 'a>(
         packet_reader: &'reader PacketParser<'_>,
     ) -> Result<ReceivedPacket<'a>, Error> {
         let (message_type, flags, remaining_length) = packet_reader.read_fixed_header()?;
@@ -298,7 +298,7 @@ mod test {
         ];
 
         let reader = PacketParser::new(&serialized_connack);
-        let connack = ReceivedPacket::parse_message(&reader).unwrap();
+        let connack = ReceivedPacket::parse_packet(&reader).unwrap();
         match connack {
             ReceivedPacket::ConnAck(conn_ack) => {
                 assert_eq!(conn_ack.reason_code, 0);
@@ -319,7 +319,7 @@ mod test {
         ];
 
         let reader = PacketParser::new(&serialized_publish);
-        let publish = ReceivedPacket::parse_message(&reader).unwrap();
+        let publish = ReceivedPacket::parse_packet(&reader).unwrap();
         match publish {
             ReceivedPacket::Publish(pub_info) => {
                 assert_eq!(pub_info.topic, "A");
@@ -339,7 +339,7 @@ mod test {
         ];
 
         let reader = PacketParser::new(&serialized_suback);
-        let puback = ReceivedPacket::parse_message(&reader).unwrap();
+        let puback = ReceivedPacket::parse_packet(&reader).unwrap();
         match puback {
             ReceivedPacket::PubAck(pub_ack) => {
                 assert_eq!(pub_ack.reason, 0x10);
@@ -359,7 +359,7 @@ mod test {
         ];
 
         let reader = PacketParser::new(&serialized_suback);
-        let puback = ReceivedPacket::parse_message(&reader).unwrap();
+        let puback = ReceivedPacket::parse_packet(&reader).unwrap();
         match puback {
             ReceivedPacket::PubAck(pub_ack) => {
                 assert_eq!(pub_ack.reason, 0x00);
@@ -381,7 +381,7 @@ mod test {
         ];
 
         let reader = PacketParser::new(&serialized_suback);
-        let suback = ReceivedPacket::parse_message(&reader).unwrap();
+        let suback = ReceivedPacket::parse_packet(&reader).unwrap();
         match suback {
             ReceivedPacket::SubAck(sub_ack) => {
                 assert_eq!(sub_ack.reason_code, 2);
@@ -399,7 +399,7 @@ mod test {
         ];
 
         let reader = PacketParser::new(&serialized_ping_req);
-        let ping_req = ReceivedPacket::parse_message(&reader).unwrap();
+        let ping_req = ReceivedPacket::parse_packet(&reader).unwrap();
         match ping_req {
             ReceivedPacket::PingResp => {}
             _ => panic!("Invalid message"),
@@ -417,7 +417,7 @@ mod test {
             0x00, // Properties length
         ];
         let reader = PacketParser::new(&serialized_pubcomp);
-        let pub_comp = ReceivedPacket::parse_message(&reader).unwrap();
+        let pub_comp = ReceivedPacket::parse_packet(&reader).unwrap();
         match pub_comp {
             ReceivedPacket::PubComp(comp) => {
                 assert_eq!(comp.packet_id, 5);
@@ -437,7 +437,7 @@ mod test {
             0x05, // Identifier
         ];
         let reader = PacketParser::new(&serialized_pubcomp);
-        let pub_comp = ReceivedPacket::parse_message(&reader).unwrap();
+        let pub_comp = ReceivedPacket::parse_packet(&reader).unwrap();
         match pub_comp {
             ReceivedPacket::PubComp(comp) => {
                 assert_eq!(comp.packet_id, 5);
@@ -459,7 +459,7 @@ mod test {
             0x00, // Properties length
         ];
         let reader = PacketParser::new(&serialized_pubrec);
-        let pub_rec = ReceivedPacket::parse_message(&reader).unwrap();
+        let pub_rec = ReceivedPacket::parse_packet(&reader).unwrap();
         match pub_rec {
             ReceivedPacket::PubRec(rec) => {
                 assert_eq!(rec.packet_id, 5);
@@ -479,7 +479,7 @@ mod test {
             0x05, // Identifier
         ];
         let reader = PacketParser::new(&serialized_pubrec);
-        let pub_rec = ReceivedPacket::parse_message(&reader).unwrap();
+        let pub_rec = ReceivedPacket::parse_packet(&reader).unwrap();
         match pub_rec {
             ReceivedPacket::PubRec(rec) => {
                 assert_eq!(rec.packet_id, 5);

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,3 +1,5 @@
 pub mod deserialize;
+mod packet_parser;
 mod packet_reader;
+pub(crate) use packet_parser::PacketParser;
 pub(crate) use packet_reader::PacketReader;

--- a/src/de/packet_parser.rs
+++ b/src/de/packet_parser.rs
@@ -1,0 +1,133 @@
+use crate::{warn, MessageType, Property, ProtocolError as Error};
+use bit_field::BitField;
+use heapless::Vec;
+
+pub(crate) struct PacketParser<'a> {
+    pub buffer: &'a [u8],
+    index: core::cell::RefCell<usize>,
+}
+
+impl<'a> PacketParser<'a> {
+    pub fn new(buffer: &'a [u8]) -> Self {
+        Self {
+            buffer,
+            index: core::cell::RefCell::new(0),
+        }
+    }
+
+    pub fn payload(&self) -> Result<&[u8], Error> {
+        Ok(&self.buffer[*self.index.borrow()..self.buffer.len()])
+    }
+
+    pub fn read(&self, dest: &mut [u8]) -> Result<(), Error> {
+        let mut index = self.index.borrow_mut();
+
+        if *index + dest.len() > self.buffer.len() {
+            return Err(Error::DataSize);
+        }
+
+        dest.copy_from_slice(&self.buffer[*index..][..dest.len()]);
+        *index += dest.len();
+
+        Ok(())
+    }
+
+    fn read_borrowed(&self, count: usize) -> Result<&[u8], Error> {
+        let mut index = self.index.borrow_mut();
+
+        if *index + count > self.buffer.len() {
+            return Err(Error::DataSize);
+        }
+
+        let borrowed_data = &self.buffer[*index..][..count];
+        *index += count;
+
+        Ok(borrowed_data)
+    }
+
+    pub fn len(&self) -> Result<usize, Error> {
+        Ok(self.buffer.len() - *self.index.borrow())
+    }
+
+    pub fn read_variable_length_integer(&self) -> Result<usize, Error> {
+        let mut accumulator: usize = 0;
+        for i in 0..4 {
+            let mut byte = [0u8; 1];
+            self.read(&mut byte)?;
+            accumulator += ((byte[0] & 0x7F) as usize) << (i * 7);
+
+            if (byte[0] & 0x80) == 0 {
+                return Ok(accumulator);
+            }
+        }
+
+        warn!("Encountered invalid variable integer");
+        Err(Error::MalformedInteger)
+    }
+
+    pub fn read_fixed_header(&self) -> Result<(MessageType, u8, usize), Error> {
+        let header = self.read_u8()?;
+        let packet_length = self.read_variable_length_integer()?;
+
+        Ok((
+            MessageType::from(header.get_bits(4..=7)),
+            header.get_bits(0..=3),
+            packet_length,
+        ))
+    }
+
+    pub fn read_utf8_string<'b, 'me: 'b>(&'me self) -> Result<&'b str, Error> {
+        let string_length = self.read_u16()? as usize;
+
+        if self.buffer.len() < string_length {
+            return Err(Error::DataSize);
+        }
+
+        core::str::from_utf8(self.read_borrowed(string_length)?).map_err(|_| Error::MalformedPacket)
+    }
+
+    pub fn read_binary_data(&self) -> Result<&[u8], Error> {
+        let string_length = self.read_u16()? as usize;
+        self.read_borrowed(string_length)
+    }
+
+    pub fn read_u32(&self) -> Result<u32, Error> {
+        let mut buffer: [u8; 4] = [0; 4];
+        self.read(&mut buffer)?;
+        Ok(u32::from_be_bytes(buffer))
+    }
+
+    pub fn read_u16(&self) -> Result<u16, Error> {
+        let mut buffer: [u8; 2] = [0; 2];
+        self.read(&mut buffer)?;
+        Ok(u16::from_be_bytes(buffer))
+    }
+
+    pub fn read_u8(&self) -> Result<u8, Error> {
+        let mut byte: [u8; 1] = [0];
+        self.read(&mut byte)?;
+
+        Ok(byte[0])
+    }
+
+    pub fn read_properties<'b, 'me: 'b>(&'me self) -> Result<Vec<Property<'b>, 8>, Error> {
+        let mut properties: Vec<Property, 8> = Vec::new();
+
+        let properties_size = self.read_variable_length_integer()?;
+        let mut property_bytes_processed = 0;
+
+        while properties_size - property_bytes_processed > 0 {
+            let property = Property::parse(self)?;
+            property_bytes_processed += property.size();
+            properties
+                .push(property)
+                .map_err(|_| Error::MalformedPacket)?;
+        }
+
+        if properties_size != property_bytes_processed {
+            return Err(Error::MalformedPacket);
+        }
+
+        Ok(properties)
+    }
+}

--- a/src/de/packet_reader.rs
+++ b/src/de/packet_reader.rs
@@ -1,19 +1,10 @@
-use crate::{
-    message_types::MessageType,
-    Property, ProtocolError as Error, {debug, warn},
-};
-use bit_field::BitField;
-use heapless::Vec;
-
-// The maximum size of the fixed header. This is calculated as the type+flag byte and the maximum
-// variable length integer size (4).
-const FIXED_HEADER_MAX: usize = 5;
+use super::packet_parser::PacketParser;
+use crate::ProtocolError as Error;
 
 pub(crate) struct PacketReader<const T: usize> {
     pub buffer: [u8; T],
     read_bytes: usize,
     packet_length: Option<usize>,
-    index: core::cell::RefCell<usize>,
 }
 
 impl<const T: usize> PacketReader<T> {
@@ -22,218 +13,30 @@ impl<const T: usize> PacketReader<T> {
             buffer: [0; T],
             read_bytes: 0,
             packet_length: None,
-            index: core::cell::RefCell::new(0),
         }
     }
 
-    #[cfg(test)]
-    pub fn from_serialized<'a>(buffer: &'a mut [u8]) -> PacketReader<T> {
-        let len = buffer.len();
-        let mut reader = PacketReader {
-            buffer: [0; T],
-            read_bytes: len,
-            packet_length: None,
-            index: core::cell::RefCell::new(0),
-        };
-
-        reader.buffer[..buffer.len()].copy_from_slice(buffer);
-
-        reader.probe_fixed_header();
-
-        reader
-    }
-
-    pub fn payload(&self) -> Result<&[u8], Error> {
-        Ok(&self.buffer[*self.index.borrow()..self.packet_length()?])
-    }
-
-    pub fn read(&self, dest: &mut [u8]) -> Result<(), Error> {
-        let mut index = self.index.borrow_mut();
-
-        if *index + dest.len() > self.packet_length()? {
-            return Err(Error::DataSize);
+    pub fn receive_buffer(&mut self) -> Result<&mut [u8], Error> {
+        if self.packet_length.is_none() {
+            self.probe_fixed_header()?;
         }
 
-        dest.copy_from_slice(&self.buffer[*index..][..dest.len()]);
-        *index += dest.len();
-
-        Ok(())
-    }
-
-    fn read_borrowed(&self, count: usize) -> Result<&[u8], Error> {
-        let mut index = self.index.borrow_mut();
-
-        if *index + count > self.packet_length()? {
-            return Err(Error::DataSize);
-        }
-
-        let borrowed_data = &self.buffer[*index..][..count];
-        *index += count;
-
-        Ok(borrowed_data)
-    }
-
-    pub fn remaining_len(&self) -> Result<usize, Error> {
-        Ok(self.packet_length()? - *self.index.borrow())
-    }
-
-    pub fn len(&self) -> Result<usize, Error> {
-        Ok(self.packet_length()? - *self.index.borrow())
-    }
-
-    pub fn read_variable_length_integer(&self) -> Result<usize, Error> {
-        let mut accumulator: usize = 0;
-        for i in 0..4 {
-            let mut byte = [0u8; 1];
-            self.read(&mut byte)?;
-            accumulator += ((byte[0] & 0x7F) as usize) << (i * 7);
-
-            if (byte[0] & 0x80) == 0 {
-                return Ok(accumulator);
-            }
-        }
-
-        warn!("Encountered invalid variable integer");
-        Err(Error::MalformedInteger)
-    }
-
-    pub fn read_fixed_header(&self) -> Result<(MessageType, u8, usize), Error> {
-        let header = self.read_u8()?;
-        let packet_length = self.read_variable_length_integer()?;
-
-        Ok((
-            MessageType::from(header.get_bits(4..=7)),
-            header.get_bits(0..=3),
-            packet_length,
-        ))
-    }
-
-    pub fn read_utf8_string<'a, 'me: 'a>(&'me self) -> Result<&'a str, Error> {
-        let string_length = self.read_u16()? as usize;
-
-        if self.buffer.len() < string_length {
-            return Err(Error::DataSize);
-        }
-
-        core::str::from_utf8(self.read_borrowed(string_length)?).map_err(|_| Error::MalformedPacket)
-    }
-
-    pub fn read_binary_data(&self) -> Result<&[u8], Error> {
-        let string_length = self.read_u16()? as usize;
-        self.read_borrowed(string_length)
-    }
-
-    pub fn read_u32(&self) -> Result<u32, Error> {
-        let mut buffer: [u8; 4] = [0; 4];
-        self.read(&mut buffer)?;
-        Ok(u32::from_be_bytes(buffer))
-    }
-
-    pub fn read_u16(&self) -> Result<u16, Error> {
-        let mut buffer: [u8; 2] = [0; 2];
-        self.read(&mut buffer)?;
-        Ok(u16::from_be_bytes(buffer))
-    }
-
-    pub fn read_u8(&self) -> Result<u8, Error> {
-        let mut byte: [u8; 1] = [0];
-        self.read(&mut byte)?;
-
-        Ok(byte[0])
-    }
-
-    pub fn read_properties<'a, 'me: 'a>(&'me self) -> Result<Vec<Property<'a>, 8>, Error> {
-        let mut properties: Vec<Property, 8> = Vec::new();
-
-        let properties_size = self.read_variable_length_integer()?;
-        let mut property_bytes_processed = 0;
-
-        while properties_size - property_bytes_processed > 0 {
-            let property = Property::parse(self)?;
-            property_bytes_processed += property.size();
-            properties
-                .push(property)
-                .map_err(|_| Error::MalformedPacket)?;
-        }
-
-        if properties_size != property_bytes_processed {
-            return Err(Error::MalformedPacket);
-        }
-
-        Ok(properties)
-    }
-
-    pub fn packet_length(&self) -> Result<usize, Error> {
-        if let Some(packet_length) = self.packet_length {
-            Ok(packet_length)
+        let end = if let Some(packet_length) = &self.packet_length {
+            *packet_length
         } else {
-            Err(Error::MalformedPacket)
-        }
-    }
-
-    pub fn packet_available(&self) -> bool {
-        match self.packet_length {
-            Some(length) => self.read_bytes >= length,
-            None => false,
-        }
-    }
-
-    pub fn pop_packet(&mut self) -> Result<(), Error> {
-        let packet_length = self.packet_length()?;
-        debug!("Popping packet of {} bytes", packet_length);
-
-        let move_length = self.read_bytes - packet_length;
-
-        // Move data after the packet to the front.
-        unsafe {
-            let head: *mut u8 = &mut self.buffer[0] as *mut u8;
-            let tail: *const u8 = &self.buffer[packet_length] as *const u8;
-            core::intrinsics::copy(tail, head, move_length);
+            self.read_bytes + 1
         };
 
-        // Reset the read_bytes counter.
-        self.read_bytes = move_length;
-
-        // Reset the reader index.
-        self.index.replace(0);
-
-        // Probe the fixed header to update the length in case a packet still exists to be
-        // processed.
-        self.probe_fixed_header();
-
-        Ok(())
+        Ok(&mut self.buffer[self.read_bytes..end])
     }
 
-    pub fn reset(&mut self) {
-        self.read_bytes = 0;
-        self.packet_length = None;
+    pub fn commit(&mut self, count: usize) {
+        self.read_bytes += count;
     }
 
-    pub fn fill(&mut self, stream: &[u8]) -> usize {
-        let read = core::cmp::min(stream.len(), self.buffer.len() - self.read_bytes);
-        self.buffer[self.read_bytes..][..read].copy_from_slice(&stream[..read]);
-        self.read_bytes += read;
-        read
-    }
-
-    pub fn slurp(&mut self, stream: &[u8]) -> Result<usize, Error> {
-        let read = self.fill(stream);
-        if let Some(total_len) = self.probe_fixed_header() {
-            if self.packet_length != None {
-                if total_len > self.buffer.len() {
-                    return Err(Error::PacketSize);
-                }
-            } else if self.read_bytes >= FIXED_HEADER_MAX {
-                return Err(Error::MalformedPacket);
-            }
-        }
-
-        Ok(read)
-    }
-
-    pub fn probe_fixed_header(&mut self) -> Option<usize> {
+    fn probe_fixed_header(&mut self) -> Result<(), Error> {
         if self.read_bytes <= 1 {
-            return None;
+            return Ok(());
         }
 
         self.packet_length = None;
@@ -252,6 +55,28 @@ impl<const T: usize> PacketReader<T> {
             }
         }
 
-        self.packet_length
+        // We should have found the packet length by now.
+        if self.read_bytes >= 5 && self.packet_length.is_none() {
+            return Err(Error::MalformedPacket);
+        }
+
+        Ok(())
+    }
+
+    pub fn packet_available(&self) -> bool {
+        match self.packet_length {
+            Some(length) => self.read_bytes >= length,
+            None => false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.read_bytes = 0;
+        self.packet_length = None;
+    }
+
+    pub fn received_packet(&self) -> Result<PacketParser<'_>, Error> {
+        let packet_length = self.packet_length.as_ref().ok_or(Error::PacketSize)?;
+        Ok(PacketParser::new(&self.buffer[..*packet_length]))
     }
 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -273,7 +273,7 @@ impl<
         let packet_id = self.sm.context_mut().session_state.get_packet_identifier();
 
         let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
-        let packet = serialize::subscribe_message(&mut buffer, topic, packet_id, properties)?;
+        let packet = serialize::subscribe_packet(&mut buffer, topic, packet_id, properties)?;
 
         info!("Subscribing to `{}`: {}", topic, packet_id);
         self.network.write(packet)?;
@@ -371,7 +371,7 @@ impl<
 
         let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
         let packet =
-            serialize::publish_message(&mut buffer, topic, data, qos, retain, id, properties)?;
+            serialize::publish_packet(&mut buffer, topic, data, qos, retain, id, properties)?;
 
         self.network.write(packet)?;
 
@@ -398,7 +398,7 @@ impl<
         ];
 
         let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
-        let packet = serialize::connect_message(
+        let packet = serialize::connect_packet(
             &mut buffer,
             self.sm
                 .context()
@@ -451,7 +451,7 @@ impl<
 
             // Note: If we fail to serialize or write the packet, the ping timeout timer is
             // still running, so we will recover the TCP connection in the future.
-            let packet = serialize::ping_req_message(&mut buffer)?;
+            let packet = serialize::ping_req_packet(&mut buffer)?;
             self.network.write(packet)?;
         }
 
@@ -517,7 +517,7 @@ impl<
                 }
 
                 let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
-                let packet = serialize::pubrel_message(&mut buffer, rec.packet_id, 0, &[])?;
+                let packet = serialize::pubrel_packet(&mut buffer, rec.packet_id, 0, &[])?;
                 info!("Sending PubRel({})", rec.packet_id);
                 self.network.write(packet)?;
 
@@ -648,7 +648,7 @@ impl<
         // of the loop on availability above.
         let packet = self.packet_reader.received_packet().unwrap();
 
-        let packet = ReceivedPacket::parse_message(&packet)?;
+        let packet = ReceivedPacket::parse_packet(&packet)?;
         info!("Received {:?}", packet);
 
         let result = self.client.handle_packet(packet, &mut f);

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    de::PacketReader,
+    de::PacketParser,
     ser::{serialize::integer_size, ReversedPacketWriter},
     ProtocolError as Error,
 };
@@ -131,8 +131,8 @@ impl<'a> Property<'a> {
         }
     }
 
-    pub(crate) fn parse<'reader: 'a, const T: usize>(
-        packet: &'reader PacketReader<T>,
+    pub(crate) fn parse<'reader: 'a>(
+        packet: &'reader PacketParser<'_>,
     ) -> Result<Property<'a>, Error> {
         let identifier: PropertyIdentifier = packet.read_variable_length_integer()?.into();
 

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -19,7 +19,7 @@ pub fn integer_size(value: usize) -> usize {
     }
 }
 
-pub fn connect_message<'a, const S: usize>(
+pub fn connect_packet<'a, const S: usize>(
     dest: &'a mut [u8],
     client_id: &[u8],
     keep_alive: u16,
@@ -74,11 +74,11 @@ pub fn connect_message<'a, const S: usize>(
     packet.finalize(MessageType::Connect, 0)
 }
 
-pub fn ping_req_message(dest: &mut [u8]) -> Result<&[u8], Error> {
+pub fn ping_req_packet(dest: &mut [u8]) -> Result<&[u8], Error> {
     ReversedPacketWriter::new(dest).finalize(MessageType::PingReq, 0x00)
 }
 
-pub fn publish_message<'a, 'b, 'c>(
+pub fn publish_packet<'a, 'b, 'c>(
     dest: &'b mut [u8],
     topic: &'a str,
     payload: &[u8],
@@ -126,7 +126,7 @@ pub fn publish_message<'a, 'b, 'c>(
     packet.finalize(MessageType::Publish, flags)
 }
 
-pub fn subscribe_message<'a, 'b, 'c>(
+pub fn subscribe_packet<'a, 'b, 'c>(
     dest: &'c mut [u8],
     topic: &'b str,
     packet_id: u16,
@@ -156,7 +156,7 @@ pub fn subscribe_message<'a, 'b, 'c>(
     packet.finalize(MessageType::Subscribe, 0b0010)
 }
 
-pub fn pubrel_message<'c, 'a>(
+pub fn pubrel_packet<'c, 'a>(
     dest: &'c mut [u8],
     packet_id: u16,
     reason: u8,
@@ -187,7 +187,7 @@ pub fn serialize_publish() {
 
     let mut buffer: [u8; 900] = [0; 900];
     let payload: [u8; 2] = [0xAB, 0xCD];
-    let message = publish_message(
+    let message = publish_packet(
         &mut buffer,
         "ABC",
         &payload,
@@ -214,7 +214,7 @@ pub fn serialize_publish_qos1() {
 
     let mut buffer: [u8; 900] = [0; 900];
     let payload: [u8; 2] = [0xAB, 0xCD];
-    let message = publish_message(
+    let message = publish_packet(
         &mut buffer,
         "ABC",
         &payload,
@@ -240,7 +240,7 @@ fn serialize_subscribe() {
     ];
 
     let mut buffer: [u8; 900] = [0; 900];
-    let message = subscribe_message(&mut buffer, "ABC", 16, &[]).unwrap();
+    let message = subscribe_packet(&mut buffer, "ABC", 16, &[]).unwrap();
 
     assert_eq!(message, good_subscribe);
 }
@@ -258,7 +258,7 @@ pub fn serialize_publish_with_properties() {
 
     let mut buffer: [u8; 900] = [0; 900];
     let payload: [u8; 2] = [0xAB, 0xCD];
-    let message = publish_message(
+    let message = publish_packet(
         &mut buffer,
         "ABC",
         &payload,
@@ -286,7 +286,7 @@ fn serialize_connect() {
 
     let mut buffer: [u8; 900] = [0; 900];
     let client_id = "ABC".as_bytes();
-    let message = connect_message::<100>(&mut buffer, client_id, 10, &[], true, None).unwrap();
+    let message = connect_packet::<100>(&mut buffer, client_id, 10, &[], true, None).unwrap();
 
     assert_eq!(message, good_serialized_connect)
 }
@@ -325,7 +325,7 @@ fn serialize_connect_with_will() {
     will.qos(QoS::AtMostOnce);
     will.retained(Retain::NotRetained);
 
-    let message = connect_message(&mut buffer, client_id, 10, &[], true, Some(&will)).unwrap();
+    let message = connect_packet(&mut buffer, client_id, 10, &[], true, Some(&will)).unwrap();
 
     assert_eq!(message, good_serialized_connect)
 }
@@ -338,7 +338,7 @@ fn serialize_ping_req() {
     ];
 
     let mut buffer: [u8; 1024] = [0; 1024];
-    assert_eq!(ping_req_message(&mut buffer).unwrap(), good_ping_req);
+    assert_eq!(ping_req_packet(&mut buffer).unwrap(), good_ping_req);
 }
 
 #[test]
@@ -354,7 +354,7 @@ fn serialize_pubrel() {
 
     let mut buffer: [u8; 1024] = [0; 1024];
     assert_eq!(
-        pubrel_message(&mut buffer, 5, 0x10, &[]).unwrap(),
+        pubrel_packet(&mut buffer, 5, 0x10, &[]).unwrap(),
         good_pubrel
     );
 }
@@ -370,7 +370,7 @@ fn serialize_short_pubrel() {
 
     let mut buffer: [u8; 1024] = [0; 1024];
     assert_eq!(
-        pubrel_message(&mut buffer, 5, 0x0, &[]).unwrap(),
+        pubrel_packet(&mut buffer, 5, 0x0, &[]).unwrap(),
         good_pubrel
     );
 }


### PR DESCRIPTION
This PR refactors the packet reception mechanism in Minimq to receive directly from the network stack into the `PacketReader`. The `PacketParser` has been broken off the `PacketReader` in anticipation of deserialization refactoring in the future.

This avoids one copy of the MQTT packet from the receive buffer into the packet reader.

Additionally, this PR updates it so that only a single MQTT packet is read from the network per `poll()` execution at most, which paves the way for fixing #80.