### PR TITLE
Adding support for returning results from poll closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This document describes the changes to Minimq between releases.
 ## Added
 * Allow configuration of non-default broker port numbers
 * Support added for QoS::ExactlyOnce transmission
+* `poll()` now supports returning from the closure. An `Option::Some()` will be generated whenever
+the `poll()` closure executes on an inbound `Publish` message.
 
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -483,18 +483,18 @@ impl<
         Ok(())
     }
 
-    fn handle_packet<'a, F>(
+    fn handle_packet<'a, F, T>(
         &mut self,
         packet: ReceivedPacket<'a>,
         f: &mut F,
-    ) -> Result<(), Error<TcpStack::Error>>
+    ) -> Result<Option<T>, Error<TcpStack::Error>>
     where
         F: FnMut(
             &mut MqttClient<TcpStack, Clock, MSG_SIZE, MSG_COUNT>,
             &'a str,
             &[u8],
             &[Property<'a>],
-        ),
+        ) -> T,
     {
         match packet {
             ReceivedPacket::ConnAck(ack) => {
@@ -503,7 +503,7 @@ impl<
                 return if self.sm.context_mut().session_state.was_reset() {
                     Err(Error::SessionReset)
                 } else {
-                    Ok(())
+                    Ok(None)
                 };
             }
 
@@ -533,7 +533,7 @@ impl<
                     return Err(Error::Protocol(ProtocolError::Invalid));
                 }
 
-                f(self, info.topic, info.payload, &info.properties);
+                return Ok(Some(f(self, info.topic, info.payload, &info.properties)));
             }
 
             _ => {
@@ -541,7 +541,7 @@ impl<
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 }
 
@@ -603,14 +603,14 @@ impl<
     /// # Args
     /// * `f` - A closure to process any received messages. The closure should accept the client,
     /// topic, message, and list of proprties (in that order).
-    pub fn poll<F>(&mut self, mut f: F) -> Result<(), Error<TcpStack::Error>>
+    pub fn poll<F, T>(&mut self, mut f: F) -> Result<Option<T>, Error<TcpStack::Error>>
     where
         for<'a> F: FnMut(
             &mut MqttClient<TcpStack, Clock, MSG_SIZE, MSG_COUNT>,
             &'a str,
             &[u8],
             &[Property<'a>],
-        ),
+        ) -> T,
     {
         self.client.update()?;
 
@@ -620,7 +620,7 @@ impl<
             && self.client.sm.state() != &States::Establishing
         {
             self.packet_reader.reset();
-            return Ok(());
+            return Ok(None);
         }
 
         // Attempt to read an MQTT packet from the network.
@@ -640,7 +640,7 @@ impl<
             if received > 0 {
                 debug!("Received {} bytes", received);
             } else {
-                return Ok(());
+                return Ok(None);
             }
         }
 

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -1,0 +1,57 @@
+use minimq::{Minimq, QoS, Retain};
+
+use embedded_nal::{self, IpAddr, Ipv4Addr};
+use std_embedded_time::StandardClock;
+
+#[test]
+fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    let stack = std_embedded_nal::Stack::default();
+    let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let mut mqtt =
+        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+
+    // Use a keepalive interval for the client.
+    mqtt.client().set_keepalive_interval(60).unwrap();
+
+    let mut published = false;
+    let mut subscribed = false;
+
+    loop {
+        if mqtt
+            .poll(|_client, topic, _payload, _properties| topic == "data")
+            .unwrap()
+            .unwrap_or(false)
+        {
+            log::info!("Transmission complete");
+            std::process::exit(0);
+        }
+
+        if !mqtt.client().is_connected() {
+            continue;
+        }
+
+        if !subscribed {
+            mqtt.client().subscribe("data", &[]).unwrap();
+            subscribed = true;
+        }
+
+        if !mqtt.client().subscriptions_pending()
+            && !published
+            && mqtt.client().can_publish(QoS::ExactlyOnce)
+        {
+            mqtt.client()
+                .publish(
+                    "data",
+                    "Ping".as_bytes(),
+                    QoS::ExactlyOnce,
+                    Retain::NotRetained,
+                    &[],
+                )
+                .unwrap();
+            log::info!("Publishing message");
+            published = true;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #80 by adding support for returning data from `poll()`'s closure. This can be used to propogate behavior to the higher level without using mutable state.