### PR TITLE
Feature/doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Minimq supports all of the fundamental operations of MQTT, such as message subsc
 publication. Below is a detailed list of features, indicating what aspects are supported and what
 aren't:
 * Will messages are fully supported.
-* Message subscription is fully supported.
 * Message publication is supported for all quality-of-service (QoS) levels
-* Message reception is only supported for the following QoS levels:
+* Message subscription is only supported for the following QoS levels:
     1. At Most once (Level 0)
+* Topic aliasing is not yet supported
 
 If there are features that you would like to have that are not yet supported, we are always
 accepting pull requests to extend Minimq's capabilities.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,8 @@
 //!
 //! # Limitations
 //! This library does not currently support the following elements:
-//! * Quality-of-service `ExactlyOnce`
-//! * Quality-of-service above `AtMostOnce` for inbound messages.
-//! * Bulk subscriptions
+//! * Subscribing above Quality-of-service `AtMostOnce`
 //! * Server Authentication
-//! * Encryption
 //! * Topic aliases
 //!
 //! # Requirements
@@ -23,9 +20,7 @@
 //! is important to select a size such that the stack does not overflow.
 //!
 //! # Example
-//! Below is a sample snippet showing how this library is used. An example application is provided
-//! in `examples/minimq-stm32h7`, which targets the Nucleo-H743 development board with an external
-//! temperature sensor installed.
+//! Below is a sample snippet showing how this library is used.
 //!
 //! ```no_run
 //! use minimq::{Minimq, QoS, Retain};
@@ -49,6 +44,7 @@
 //!         subscribed = true;
 //!     }
 //!
+//!     // The client must be continually polled to update the MQTT state machine.
 //!     mqtt.poll(|client, topic, message, properties| {
 //!         match topic {
 //!             "topic" => {


### PR DESCRIPTION
This PR fixes #56 by updating the documents to be clear that `poll()` needs to be called repeatedly to update the MQTT state.

It also cleans up documentation in various places to keep it all up-to-date.