### PR TITLE
Leveraging external tools for variable length integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ the `poll()` closure executes on an inbound `Publish` message.
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`
 * Single MQTT packets are now processed per `Minimq::poll()` execution, reducing stack usage.
+* [breaking] External crate is now used for `varint` encoding. Varints changed to u32 format.
 
 ## Fixed
 * All unacknowledged messages will be guaranteed to be retransmitted upon connection with the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ enum-iterator = "0.6.0"
 heapless = "0.7"
 log = {version = "0.4", optional = true}
 embedded-time = "0.12"
+varint-rs = {version = "2.2", default-features = false }
 
 [dependencies.smlang]
 git = "https://github.com/ryan-summers/smlang-rs"

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,8 +1,4 @@
-use crate::{
-    de::PacketParser,
-    ser::{serialize::integer_size, ReversedPacketWriter},
-    ProtocolError as Error,
-};
+use crate::{de::PacketParser, ser::ReversedPacketWriter, ProtocolError as Error};
 
 use enum_iterator::IntoEnumIterator;
 
@@ -54,7 +50,7 @@ pub enum Property<'a> {
     ContentType(&'a str),
     ResponseTopic(&'a str),
     CorrelationData(&'a [u8]),
-    SubscriptionIdentifier(usize),
+    SubscriptionIdentifier(u32),
     SessionExpiryInterval(u32),
     AssignedClientIdentifier(&'a str),
     ServerKeepAlive(u16),
@@ -78,10 +74,10 @@ pub enum Property<'a> {
     SharedSubscriptionAvailable(u8),
 }
 
-impl From<usize> for PropertyIdentifier {
-    fn from(val: usize) -> Self {
+impl From<u32> for PropertyIdentifier {
+    fn from(val: u32) -> Self {
         for entry in Self::into_enum_iter() {
-            if entry as usize == val {
+            if entry as u32 == val {
                 return entry;
             }
         }
@@ -90,9 +86,9 @@ impl From<usize> for PropertyIdentifier {
     }
 }
 
-impl<'a> Property<'a> {
-    pub(crate) fn id(&self) -> PropertyIdentifier {
-        match self {
+impl<'a> From<&Property<'a>> for PropertyIdentifier {
+    fn from(prop: &Property<'a>) -> PropertyIdentifier {
+        match prop {
             Property::PayloadFormatIndicator(_) => PropertyIdentifier::PayloadFormatIndicator,
             Property::MessageExpiryInterval(_) => PropertyIdentifier::MessageExpiryInterval,
             Property::ContentType(_) => PropertyIdentifier::ContentType,
@@ -130,7 +126,9 @@ impl<'a> Property<'a> {
             }
         }
     }
+}
 
+impl<'a> Property<'a> {
     pub(crate) fn parse<'reader: 'a>(
         packet: &'reader PacketParser<'_>,
     ) -> Result<Property<'a>, Error> {
@@ -216,258 +214,46 @@ impl<'a> Property<'a> {
         }
     }
 
-    pub(crate) fn size(&self) -> usize {
-        // Although property identifiers are technically encoded as variable length integers, in
-        // practice, they are all small enough to fit in 1 byte.
-        let identifier_length = 1;
-
-        match self {
-            Property::ContentType(data)
-            | Property::ResponseTopic(data)
-            | Property::AuthenticationMethod(data)
-            | Property::ResponseInformation(data)
-            | Property::ServerReference(data)
-            | Property::ReasonString(data)
-            | Property::AssignedClientIdentifier(data) => data.len() + 2 + identifier_length,
-            Property::UserProperty(key, value) => {
-                (value.len() + 2) + (key.len() + 2) + identifier_length
-            }
-            Property::CorrelationData(data) | Property::AuthenticationData(data) => {
-                data.len() + 2 + identifier_length
-            }
-            Property::SubscriptionIdentifier(id) => integer_size(*id),
-
-            Property::MessageExpiryInterval(_)
-            | Property::SessionExpiryInterval(_)
-            | Property::WillDelayInterval(_)
-            | Property::MaximumPacketSize(_) => 4 + identifier_length,
-            Property::ServerKeepAlive(_)
-            | Property::ReceiveMaximum(_)
-            | Property::TopicAliasMaximum(_)
-            | Property::TopicAlias(_) => 2 + identifier_length,
-            Property::PayloadFormatIndicator(_)
-            | Property::RequestProblemInformation(_)
-            | Property::RequestResponseInformation(_)
-            | Property::MaximumQoS(_)
-            | Property::RetainAvailable(_)
-            | Property::WildcardSubscriptionAvailable(_)
-            | Property::SubscriptionIdentifierAvailable(_)
-            | Property::SharedSubscriptionAvailable(_) => 1 + identifier_length,
-        }
-    }
-
     pub(crate) fn encode_into<'b>(
         &self,
         packet: &mut ReversedPacketWriter<'b>,
     ) -> Result<(), Error> {
         match self {
-            Property::PayloadFormatIndicator(value) => Property::encode_byte_property(
-                packet,
-                PropertyIdentifier::PayloadFormatIndicator,
-                value,
-            ),
-            Property::MessageExpiryInterval(value) => Property::encode_four_byte_integer_property(
-                packet,
-                PropertyIdentifier::MessageExpiryInterval,
-                value,
-            ),
-            Property::ContentType(content_type) => Property::encode_string_property(
-                packet,
-                PropertyIdentifier::ContentType,
-                content_type,
-            ),
-            Property::ResponseTopic(topic) => {
-                Property::encode_string_property(packet, PropertyIdentifier::ResponseTopic, topic)
-            }
-            Property::CorrelationData(data) => Property::encode_binary_data_property(
-                packet,
-                PropertyIdentifier::CorrelationData,
-                data,
-            ),
+            Property::PayloadFormatIndicator(value) => packet.write_u8(*value)?,
+            Property::MessageExpiryInterval(value) => packet.write_u32(*value)?,
+            Property::ContentType(content_type) => packet.write_utf8_string(content_type)?,
+            Property::ResponseTopic(topic) => packet.write_utf8_string(topic)?,
+            Property::CorrelationData(data) => packet.write_binary_data(data)?,
             Property::SubscriptionIdentifier(data) => {
-                Property::encode_variable_length_integer_property(
-                    packet,
-                    PropertyIdentifier::SubscriptionIdentifier,
-                    data,
-                )
+                packet.write_variable_length_integer(*data)?
             }
-            Property::SessionExpiryInterval(data) => Property::encode_four_byte_integer_property(
-                packet,
-                PropertyIdentifier::SessionExpiryInterval,
-                data,
-            ),
-            Property::AssignedClientIdentifier(data) => Property::encode_string_property(
-                packet,
-                PropertyIdentifier::AssignedClientIdentifier,
-                data,
-            ),
-            Property::ServerKeepAlive(data) => Property::encode_two_byte_integer_property(
-                packet,
-                PropertyIdentifier::ServerKeepAlive,
-                data,
-            ),
-            Property::AuthenticationMethod(data) => Property::encode_string_property(
-                packet,
-                PropertyIdentifier::AuthenticationMethod,
-                data,
-            ),
-            Property::AuthenticationData(data) => Property::encode_binary_data_property(
-                packet,
-                PropertyIdentifier::AuthenticationData,
-                data,
-            ),
-            Property::RequestProblemInformation(data) => Property::encode_byte_property(
-                packet,
-                PropertyIdentifier::RequestProblemInformation,
-                data,
-            ),
-            Property::WillDelayInterval(data) => Property::encode_four_byte_integer_property(
-                packet,
-                PropertyIdentifier::WillDelayInterval,
-                data,
-            ),
-            Property::RequestResponseInformation(data) => Property::encode_byte_property(
-                packet,
-                PropertyIdentifier::RequestResponseInformation,
-                data,
-            ),
-            Property::ResponseInformation(data) => Property::encode_string_property(
-                packet,
-                PropertyIdentifier::ResponseInformation,
-                data,
-            ),
-            Property::ServerReference(data) => {
-                Property::encode_string_property(packet, PropertyIdentifier::ServerReference, data)
+            Property::SessionExpiryInterval(data) => packet.write_u32(*data)?,
+            Property::AssignedClientIdentifier(data) => packet.write_utf8_string(data)?,
+            Property::ServerKeepAlive(data) => packet.write_u16(*data)?,
+            Property::AuthenticationMethod(data) => packet.write_utf8_string(data)?,
+            Property::AuthenticationData(data) => packet.write_binary_data(data)?,
+            Property::RequestProblemInformation(data) => packet.write_u8(*data)?,
+            Property::WillDelayInterval(data) => packet.write_u32(*data)?,
+            Property::RequestResponseInformation(data) => packet.write_u8(*data)?,
+            Property::ResponseInformation(data) => packet.write_utf8_string(data)?,
+            Property::ServerReference(data) => packet.write_utf8_string(data)?,
+            Property::ReasonString(data) => packet.write_utf8_string(data)?,
+            Property::ReceiveMaximum(data) => packet.write_u16(*data)?,
+            Property::TopicAliasMaximum(data) => packet.write_u16(*data)?,
+            Property::TopicAlias(data) => packet.write_u16(*data)?,
+            Property::MaximumQoS(data) => packet.write_u8(*data)?,
+            Property::RetainAvailable(data) => packet.write_u8(*data)?,
+            Property::UserProperty(key, value) => {
+                packet.write_utf8_string(value)?;
+                packet.write_utf8_string(key)?;
             }
-            Property::ReasonString(data) => {
-                Property::encode_string_property(packet, PropertyIdentifier::ReasonString, data)
-            }
-            Property::ReceiveMaximum(data) => Property::encode_two_byte_integer_property(
-                packet,
-                PropertyIdentifier::ReceiveMaximum,
-                data,
-            ),
-            Property::TopicAliasMaximum(data) => Property::encode_two_byte_integer_property(
-                packet,
-                PropertyIdentifier::TopicAliasMaximum,
-                data,
-            ),
-            Property::TopicAlias(data) => Property::encode_two_byte_integer_property(
-                packet,
-                PropertyIdentifier::TopicAlias,
-                data,
-            ),
-            Property::MaximumQoS(data) => {
-                Property::encode_byte_property(packet, PropertyIdentifier::MaximumQoS, data)
-            }
-            Property::RetainAvailable(data) => {
-                Property::encode_byte_property(packet, PropertyIdentifier::RetainAvailable, data)
-            }
-            Property::UserProperty(key, value) => Property::encode_string_pair_property(
-                packet,
-                PropertyIdentifier::UserProperty,
-                key,
-                value,
-            ),
-            Property::MaximumPacketSize(data) => Property::encode_four_byte_integer_property(
-                packet,
-                PropertyIdentifier::MaximumPacketSize,
-                data,
-            ),
-            Property::WildcardSubscriptionAvailable(data) => Property::encode_byte_property(
-                packet,
-                PropertyIdentifier::WildcardSubscriptionAvailable,
-                data,
-            ),
-            Property::SubscriptionIdentifierAvailable(data) => Property::encode_byte_property(
-                packet,
-                PropertyIdentifier::SubscriptionIdentifierAvailable,
-                data,
-            ),
-            Property::SharedSubscriptionAvailable(data) => Property::encode_byte_property(
-                packet,
-                PropertyIdentifier::SharedSubscriptionAvailable,
-                data,
-            ),
-        }
-    }
+            Property::MaximumPacketSize(data) => packet.write_u32(*data)?,
+            Property::WildcardSubscriptionAvailable(data) => packet.write_u8(*data)?,
+            Property::SubscriptionIdentifierAvailable(data) => packet.write_u8(*data)?,
+            Property::SharedSubscriptionAvailable(data) => packet.write_u8(*data)?,
+        };
 
-    fn encode_string_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        text: &'a str,
-    ) -> Result<(), Error> {
-        packet.write_utf8_string(text)?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
-    }
-
-    fn encode_byte_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        byte: &u8,
-    ) -> Result<(), Error> {
-        packet.write(&[*byte])?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
-    }
-
-    fn encode_variable_length_integer_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        value: &usize,
-    ) -> Result<(), Error> {
-        packet.write_variable_length_integer(*value)?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
-    }
-
-    fn encode_four_byte_integer_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        value: &u32,
-    ) -> Result<(), Error> {
-        packet.write_u32(*value)?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
-    }
-
-    fn encode_binary_data_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        data: &[u8],
-    ) -> Result<(), Error> {
-        packet.write_binary_data(data)?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
-    }
-
-    fn encode_two_byte_integer_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        value: &u16,
-    ) -> Result<(), Error> {
-        packet.write_u16(*value)?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
-    }
-
-    fn encode_string_pair_property<'b>(
-        packet: &mut ReversedPacketWriter<'b>,
-        id: PropertyIdentifier,
-        key: &'a str,
-        value: &'a str,
-    ) -> Result<(), Error> {
-        packet.write_utf8_string(value)?;
-        packet.write_utf8_string(key)?;
-        packet.write_variable_length_integer(id as usize)?;
-
-        Ok(())
+        let id: PropertyIdentifier = self.into();
+        packet.write_variable_length_integer(id as u32)
     }
 }

--- a/src/ser/serialize.rs
+++ b/src/ser/serialize.rs
@@ -5,20 +5,6 @@ use crate::{
 
 use bit_field::BitField;
 
-pub fn integer_size(value: usize) -> usize {
-    if value < 0x80 {
-        1
-    } else if value < 0x7FFF {
-        2
-    } else if value < 0x7F_FFFF {
-        3
-    } else if value < 0x7FFF_FFFF {
-        4
-    } else {
-        panic!("Invalid integer");
-    }
-}
-
 pub fn connect_packet<'a, const S: usize>(
     dest: &'a mut [u8],
     client_id: &[u8],
@@ -29,7 +15,7 @@ pub fn connect_packet<'a, const S: usize>(
 ) -> Result<&'a [u8], Error> {
     // Validate the properties for this packet.
     for property in properties {
-        match property.id() {
+        match property.into() {
             PropertyIdentifier::SessionExpiryInterval
             | PropertyIdentifier::AuthenticationMethod
             | PropertyIdentifier::AuthenticationData
@@ -89,7 +75,7 @@ pub fn publish_packet<'a, 'b, 'c>(
 ) -> Result<&'b [u8], Error> {
     // Validate the properties for this packet.
     for property in properties {
-        match property.id() {
+        match property.into() {
             PropertyIdentifier::ResponseTopic
             | PropertyIdentifier::PayloadFormatIndicator
             | PropertyIdentifier::MessageExpiryInterval
@@ -134,7 +120,7 @@ pub fn subscribe_packet<'a, 'b, 'c>(
 ) -> Result<&'c [u8], Error> {
     // Validate the properties for this packet.
     for property in properties {
-        match property.id() {
+        match property.into() {
             PropertyIdentifier::SubscriptionIdentifier => {}
             _ => {
                 return Err(Error::InvalidProperty);

--- a/src/will.rs
+++ b/src/will.rs
@@ -22,7 +22,7 @@ impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
     pub fn new(topic: &str, data: &[u8], properties: &[Property]) -> Result<Self, ProtocolError> {
         // Check that the input properties are valid for a will.
         for property in properties {
-            match property.id() {
+            match property.into() {
                 PropertyIdentifier::WillDelayInterval
                 | PropertyIdentifier::PayloadFormatIndicator
                 | PropertyIdentifier::MessageExpiryInterval


### PR DESCRIPTION
This PR updates `minimq` to leverage `varint-rs` to handle varint encoding and decoding.

It also removes some unnecessary boilerplate code in the property module to simplify how we serialize data.

Varints have been changed from `usize` to `u32`.