### PR TITLE
Refactoring `poll()` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the `poll()` closure executes on an inbound `Publish` message.
 * [breaking] External crate is now used for `varint` encoding. Varints changed to u32 format.
 * Deserialization and serialization is now handled directly by `serde`.
 * [breaking] Properties are now wrapped in MQTT-specific data types.
+* `poll()` updated such that the user should call it repeatedly until it returns `Ok(None)`.
 
 ## Fixed
 * All unacknowledged messages will be guaranteed to be retransmitted upon connection with the

--- a/src/de/packet_reader.rs
+++ b/src/de/packet_reader.rs
@@ -75,8 +75,13 @@ impl<const T: usize> PacketReader<T> {
         self.packet_length = None;
     }
 
-    pub fn received_packet(&self) -> Result<ReceivedPacket<'_>, Error> {
-        let packet_length = self.packet_length.as_ref().ok_or(Error::PacketSize)?;
-        ReceivedPacket::from_buffer(&self.buffer[..*packet_length])
+    pub fn received_packet(&mut self) -> Result<ReceivedPacket<'_>, Error> {
+        let packet_length = *self.packet_length.as_ref().ok_or(Error::PacketSize)?;
+
+        // Reset the buffer now. Once the user drops the `ReceivedPacket`, this reader will then be
+        // immediately ready to begin receiving a new packet.
+        self.reset();
+
+        ReceivedPacket::from_buffer(&self.buffer[..packet_length])
     }
 }

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -18,8 +18,12 @@ fn main() -> std::io::Result<()> {
     let mut published = false;
 
     loop {
-        mqtt.poll(|_client, _topic, _payload, _properties| {})
-            .unwrap();
+        // Continually process the client until no more data is received.
+        while mqtt
+            .poll(|_client, _topic, _payload, _properties| {})
+            .unwrap()
+            .is_some()
+        {}
 
         if mqtt.client().is_connected() && !published && mqtt.client().can_publish(QoS::ExactlyOnce)
         {

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -19,13 +19,19 @@ fn main() -> std::io::Result<()> {
     let mut subscribed = false;
 
     loop {
-        if mqtt
-            .poll(|_client, topic, _payload, _properties| topic == "data")
-            .unwrap()
-            .unwrap_or(false)
-        {
-            log::info!("Transmission complete");
-            std::process::exit(0);
+        // Service the MQTT client until there's no more data to process.
+        loop {
+            match mqtt
+                .poll(|_client, topic, _payload, _properties| topic == "data")
+                .unwrap()
+            {
+                Some(true) => {
+                    log::info!("Transmission complete");
+                    std::process::exit(0);
+                }
+                Some(_) => {}
+                None => break,
+            }
         }
 
         if !mqtt.client().is_connected() {

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -20,17 +20,13 @@ fn main() -> std::io::Result<()> {
 
     loop {
         // Service the MQTT client until there's no more data to process.
-        loop {
-            match mqtt
-                .poll(|_client, topic, _payload, _properties| topic == "data")
-                .unwrap()
-            {
-                Some(true) => {
-                    log::info!("Transmission complete");
-                    std::process::exit(0);
-                }
-                Some(_) => {}
-                None => break,
+        while let Some(complete) = mqtt
+            .poll(|_client, topic, _payload, _properties| topic == "data")
+            .unwrap()
+        {
+            if complete {
+                log::info!("Transmission complete");
+                std::process::exit(0);
             }
         }
 


### PR DESCRIPTION
This PR updates the functionality of `poll()`. Users are now informed that they should call it repeatedly until it returns `Ok(None)`. Functionality has changed such that `poll()` will process as many MQTT control packets as possible until a `publish` message is received.

This PR fixes #102 