### PR TITLE
Adding support for simply replying to inbound messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This document describes the changes to Minimq between releases.
 * Support added for QoS::ExactlyOnce transmission
 * `poll()` now supports returning from the closure. An `Option::Some()` will be generated whenever
 the `poll()` closure executes on an inbound `Publish` message.
-* Added a `reply()` API to reply to quickly inbound messages.
+* Added a `reply()` API to reply quickly inbound messages.
 
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document describes the changes to Minimq between releases.
 * Support added for QoS::ExactlyOnce transmission
 * `poll()` now supports returning from the closure. An `Option::Some()` will be generated whenever
 the `poll()` closure executes on an inbound `Publish` message.
+* Added a `reply()` API to reply to quickly inbound messages.
 
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,12 +65,14 @@ pub mod mqtt_client;
 mod network_manager;
 mod packets;
 mod properties;
+pub mod reply_options;
 mod session_state;
 pub mod types;
 mod varint;
 mod will;
 
 pub use properties::Property;
+pub use reply_options::ReplyOptions;
 
 pub use embedded_nal;
 pub use embedded_time;
@@ -171,6 +173,7 @@ pub enum Error<E> {
     NotReady,
     Unsupported,
     ProvidedClientIdTooLong,
+    NoResponseTopic,
     Failed(u8),
     Protocol(ProtocolError),
     SessionReset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,16 +65,16 @@ pub mod mqtt_client;
 mod network_manager;
 mod packets;
 mod properties;
-pub mod reply_options;
 mod reason_codes;
+pub mod reply_options;
 mod session_state;
 pub mod types;
 mod varint;
 mod will;
 
 pub use properties::Property;
-pub use reply_options::ReplyOptions;
 pub use reason_codes::ReasonCode;
+pub use reply_options::ReplyOptions;
 
 pub use embedded_nal;
 pub use embedded_time;

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -2,6 +2,7 @@ use crate::{
     de::{received_packet::ReceivedPacket, PacketReader},
     network_manager::InterfaceHolder,
     packets::{ConnAck, Connect, PingReq, Pub, PubRel, SubAck, Subscribe},
+    reply_options::ReplyOptions,
     session_state::SessionState,
     types::{Properties, SubscriptionOptions, Utf8String},
     will::Will,
@@ -385,6 +386,51 @@ impl<
             .context_mut()
             .session_state
             .handle_publish(qos, id, packet)?;
+
+        Ok(())
+    }
+
+    /// Reply to a previously-received message.
+    ///
+    /// # Generics
+    /// * `N` specifies the maximum number of properties that the reply can contain.
+    ///
+    /// # Args
+    /// * [`ReplyOptions`] - Options used for constructing the reply.
+    /// * `default_response` - An optional default response topic to reply to.
+    /// * `data` - The data containing the response.
+    /// * `qos` - The QoS to transmit the response at.
+    /// * `retain` - The retain state of the response.
+    /// * `properties` - The properties to attach to the response.
+    pub fn reply<'a, const N: usize>(
+        &mut self,
+        options: ReplyOptions<'a>,
+        data: &[u8],
+        qos: QoS,
+        retain: Retain,
+        properties: &[Property<'a>],
+    ) -> Result<(), Error<TcpStack::Error>> {
+        let response_topic = match options.response_topic {
+            Some(topic) => topic,
+            None => {
+                if options.ignore_missing_response {
+                    return Ok(());
+                }
+
+                return Err(Error::NoResponseTopic);
+            }
+        };
+        let mut properties: Vec<_, N> =
+            Vec::from_slice(properties).map_err(|_| Error::TooManyProperties)?;
+
+        // Next, copy over any correlation data to the outbound properties.
+        if let Some(cd) = options.correlation_data {
+            properties
+                .push(Property::CorrelationData(cd))
+                .map_err(|_| Error::TooManyProperties)?;
+        }
+
+        self.publish(response_topic, data, qos, retain, &properties)?;
 
         Ok(())
     }

--- a/src/reply_options.rs
+++ b/src/reply_options.rs
@@ -1,0 +1,61 @@
+use crate::{properties::Property, types::BinaryData};
+
+/// Used to specify information about replies to received MQTT messages.
+pub struct ReplyOptions<'a> {
+    pub(crate) response_topic: Option<&'a str>,
+    pub(crate) correlation_data: Option<BinaryData<'a>>,
+    pub(crate) ignore_missing_response: bool,
+}
+
+impl<'a> ReplyOptions<'a> {
+    /// Construct options for a reply from in-bound message properties.
+    ///
+    /// # Note
+    /// This API extracts the `ResponseTopic` from received properties to publish the reply to.
+    ///
+    /// `CorrelationData` present in the received properties will also be copied over.
+    ///
+    /// # Args
+    /// * `properties` - The properties of the message being replied to.
+    pub fn new(properties: &[Property<'a>]) -> Self {
+        // First, extract the response topic from the inbound properties.
+        let response_topic = properties.iter().find_map(|p| {
+            if let Property::ResponseTopic(topic) = p {
+                Some(topic.0)
+            } else {
+                None
+            }
+        });
+
+        // Next, copy over any correlation data to the outbound properties.
+        let correlation_data = properties.iter().find_map(|p| {
+            if let Property::CorrelationData(data) = p {
+                Some(*data)
+            } else {
+                None
+            }
+        });
+
+        Self {
+            response_topic,
+            correlation_data,
+            ignore_missing_response: false,
+        }
+    }
+
+    /// If specified, an outbound message without an identified response topic will be silently
+    /// dropped.
+    pub fn ignore_missing_response_topic(mut self) -> Self {
+        self.ignore_missing_response = true;
+        self
+    }
+
+    /// Specify a default response topic if no `Property::ResponseTopic` is found.
+    ///
+    /// # Args
+    /// * `topic` - The default response topic to use.
+    pub fn default_response_topic(mut self, topic: &'a str) -> Self {
+        self.response_topic = self.response_topic.or(Some(topic));
+        self
+    }
+}


### PR DESCRIPTION
This PR takes out the dirty work of managing replying to an inbound message.

There is now a convenience `reply()` API that can be used. A new `ReplyOptions` can be constructed based on the received message properties and can be further used to customize `reply()` behavior, such as ignoring cases where there is no `ResponseTopic` or using a default `ResponseTopic` when none is found.

This PR fixes #84.