### PR TITLE
Refactoring subscription API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This document describes the changes to Minimq between releases.
 * Support added for QoS::ExactlyOnce transmission
 * `poll()` now supports returning from the closure. An `Option::Some()` will be generated whenever
 the `poll()` closure executes on an inbound `Publish` message.
+* `subscribe()` now supports subscription configuration, such as retain configuration, QoS
+  specification, and no-local publications.
+* `subscribe()` modified to take a list of topic filters.
 
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -39,7 +39,10 @@ impl<'a> ReceivedPacket<'a> {
                 }
                 ReceivedPacket::SubAck(suback) => {
                     for code in remaining_payload.iter().map(|&x| ReasonCode::from(x)) {
-                        suback.codes.push(code).ok();
+                        suback
+                            .codes
+                            .push(code)
+                            .map_err(|_| ProtocolError::BufferSize)?;
                     }
                 }
                 _ => return Err(ProtocolError::MalformedPacket),

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -1,8 +1,8 @@
 use crate::{
     message_types::MessageType,
     packets::{ConnAck, Disconnect, Pub, PubAck, PubComp, PubRec, SubAck},
-    varint::Varint,
     reason_codes::ReasonCode,
+    varint::Varint,
     ProtocolError, QoS, Retain,
 };
 

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -2,6 +2,7 @@ use crate::{
     message_types::MessageType,
     packets::{ConnAck, Disconnect, Pub, PubAck, PubComp, PubRec, SubAck},
     varint::Varint,
+    reason_codes::ReasonCode,
     ProtocolError, QoS, Retain,
 };
 
@@ -35,6 +36,11 @@ impl<'a> ReceivedPacket<'a> {
             match &mut packet {
                 ReceivedPacket::Publish(publish) => {
                     publish.payload = remaining_payload;
+                }
+                ReceivedPacket::SubAck(suback) => {
+                    for code in remaining_payload.iter().map(|&x| ReasonCode::from(x)) {
+                        suback.codes.push(code).ok();
+                    }
                 }
                 _ => return Err(ProtocolError::MalformedPacket),
             }
@@ -213,7 +219,8 @@ mod test {
         let packet = ReceivedPacket::from_buffer(&serialized_suback).unwrap();
         match packet {
             ReceivedPacket::SubAck(sub_ack) => {
-                assert_eq!(sub_ack.code, ReasonCode::GrantedQos2);
+                assert_eq!(sub_ack.codes.len(), 1);
+                assert_eq!(sub_ack.codes[0], ReasonCode::GrantedQos2);
                 assert_eq!(sub_ack.packet_identifier, 5);
             }
             _ => panic!("Invalid message"),

--- a/src/design_parameters.rs
+++ b/src/design_parameters.rs
@@ -1,0 +1,8 @@
+//! # Design Parameters
+//! This module contains design constraints arbitrarily imposed on the library.
+
+/// The maximum number of subscriptions supported in a single request.
+pub const MAX_TOPICS_PER_SUBSCRIPTION: usize = 8;
+
+/// The maximum number of properties that can be received in a single message.
+pub const MAX_RX_PROPERTIES: usize = 8;

--- a/src/design_parameters.rs
+++ b/src/design_parameters.rs
@@ -1,8 +1,0 @@
-//! # Design Parameters
-//! This module contains design constraints arbitrarily imposed on the library.
-
-/// The maximum number of subscriptions supported in a single request.
-pub const MAX_TOPICS_PER_SUBSCRIPTION: usize = 8;
-
-/// The maximum number of properties that can be received in a single message.
-pub const MAX_RX_PROPERTIES: usize = 8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 mod de;
 mod ser;
 
+mod design_parameters;
 mod message_types;
 pub mod mqtt_client;
 mod network_manager;
@@ -70,7 +71,6 @@ mod session_state;
 pub mod types;
 mod varint;
 mod will;
-mod design_parameters;
 
 pub use properties::Property;
 pub use reason_codes::ReasonCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
 mod de;
 mod ser;
 
-mod design_parameters;
 mod message_types;
 pub mod mqtt_client;
 mod network_manager;
@@ -94,6 +93,12 @@ pub const MQTT_INSECURE_DEFAULT_PORT: u16 = 1883;
 /// # Note:
 /// See [IANA Port Numbers](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt)
 pub const MQTT_SECURE_DEFAULT_PORT: u16 = 8883;
+
+/// The maximum number of subscriptions supported in a single request.
+pub const MAX_TOPICS_PER_SUBSCRIPTION: usize = 8;
+
+/// The maximum number of properties that can be received in a single message.
+pub const MAX_RX_PROPERTIES: usize = 8;
 
 /// The quality-of-service for an MQTT message.
 #[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! loop {
 //!     if mqtt.client().is_connected() && !subscribed {
-//!         mqtt.client().subscribe("topic", &[]).unwrap();
+//!         mqtt.client().subscribe(&["topic".into()], &[]).unwrap();
 //!         subscribed = true;
 //!     }
 //!
@@ -70,6 +70,7 @@ mod session_state;
 pub mod types;
 mod varint;
 mod will;
+mod design_parameters;
 
 pub use properties::Property;
 pub use reason_codes::ReasonCode;
@@ -177,6 +178,7 @@ pub enum Error<E> {
     SessionReset,
     Clock(embedded_time::clock::Error),
     TooManyProperties,
+    TooManyTopics,
 }
 
 impl<E> From<embedded_time::clock::Error> for Error<E> {

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -267,7 +267,7 @@ impl<
 
         // We can only support so many received response codes. As such, make sure that we don't
         // allow too many concurrent topics.
-        if topics.len() > crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION {
+        if topics.len() > crate::MAX_TOPICS_PER_SUBSCRIPTION {
             return Err(Error::TooManyTopics);
         }
 

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -68,7 +68,7 @@ pub struct ConnAck<'a> {
 
     /// A list of properties associated with the connection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
@@ -81,7 +81,7 @@ pub struct Pub<'a> {
     pub packet_id: Option<u16>,
 
     /// The properties transmitted with the publish data.
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 
     /// The message to be transmitted.
     pub payload: &'a [u8],
@@ -153,11 +153,11 @@ pub struct SubAck<'a> {
 
     /// The optional properties associated with the acknowledgement.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 
     /// The response status code of the subscription request.
     #[serde(skip)]
-    pub codes: Vec<ReasonCode, {crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION}>,
+    pub codes: Vec<ReasonCode, { crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION }>,
 }
 
 /// An MQTT PUBREC control packet
@@ -203,7 +203,7 @@ pub struct Disconnect<'a> {
 
     /// Properties associated with the disconnection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 }
 
 /// Success information for a control packet with optional data.
@@ -239,7 +239,7 @@ struct ReasonData<'a> {
 
     /// The properties transmitted with the publish data.
     #[serde(borrow)]
-    pub _properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub _properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 }
 
 #[cfg(test)]

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1,7 +1,7 @@
 use crate::{
     properties::Property,
     reason_codes::ReasonCode,
-    types::{Properties, SubscriptionOptions, Utf8String},
+    types::{Properties, TopicFilter, Utf8String},
     will::Will,
     QoS, Retain,
 };
@@ -68,7 +68,7 @@ pub struct ConnAck<'a> {
 
     /// A list of properties associated with the connection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, 8>,
+    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
@@ -81,7 +81,7 @@ pub struct Pub<'a> {
     pub packet_id: Option<u16>,
 
     /// The properties transmitted with the publish data.
-    pub properties: Vec<Property<'a>, 8>,
+    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
 
     /// The message to be transmitted.
     pub payload: &'a [u8],
@@ -123,7 +123,7 @@ pub struct Subscribe<'a> {
     pub properties: Properties<'a>,
 
     /// A list of topic filters and associated subscription options for the subscription request.
-    pub topics: &'a [(Utf8String<'a>, SubscriptionOptions)],
+    pub topics: &'a [TopicFilter<'a>],
 }
 
 /// An MQTT PINGREQ control packet
@@ -153,10 +153,11 @@ pub struct SubAck<'a> {
 
     /// The optional properties associated with the acknowledgement.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, 8>,
+    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
 
     /// The response status code of the subscription request.
-    pub code: ReasonCode,
+    #[serde(skip)]
+    pub codes: Vec<ReasonCode, {crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION}>,
 }
 
 /// An MQTT PUBREC control packet
@@ -202,7 +203,7 @@ pub struct Disconnect<'a> {
 
     /// Properties associated with the disconnection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, 8>,
+    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
 }
 
 /// Success information for a control packet with optional data.
@@ -238,7 +239,7 @@ struct ReasonData<'a> {
 
     /// The properties transmitted with the publish data.
     #[serde(borrow)]
-    pub _properties: Vec<Property<'a>, 8>,
+    pub _properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
 }
 
 #[cfg(test)]
@@ -313,10 +314,7 @@ mod tests {
         let subscribe = crate::packets::Subscribe {
             packet_id: 16,
             properties: crate::types::Properties(&[]),
-            topics: &[(
-                crate::types::Utf8String("ABC"),
-                crate::types::SubscriptionOptions {},
-            )],
+            topics: &["ABC".into()],
         };
 
         let mut buffer: [u8; 900] = [0; 900];

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -68,7 +68,7 @@ pub struct ConnAck<'a> {
 
     /// A list of properties associated with the connection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
+    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
@@ -81,7 +81,7 @@ pub struct Pub<'a> {
     pub packet_id: Option<u16>,
 
     /// The properties transmitted with the publish data.
-    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
+    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
 
     /// The message to be transmitted.
     pub payload: &'a [u8],
@@ -153,11 +153,11 @@ pub struct SubAck<'a> {
 
     /// The optional properties associated with the acknowledgement.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
+    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
 
     /// The response status code of the subscription request.
     #[serde(skip)]
-    pub codes: Vec<ReasonCode, { crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION }>,
+    pub codes: Vec<ReasonCode, { crate::MAX_TOPICS_PER_SUBSCRIPTION }>,
 }
 
 /// An MQTT PUBREC control packet
@@ -203,7 +203,7 @@ pub struct Disconnect<'a> {
 
     /// Properties associated with the disconnection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
+    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
 }
 
 /// Success information for a control packet with optional data.
@@ -239,7 +239,7 @@ struct ReasonData<'a> {
 
     /// The properties transmitted with the publish data.
     #[serde(borrow)]
-    pub _properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
+    pub _properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,9 @@
 //! MQTT-Specific Data Types
 //!
 //! This module provides wrapper methods and serde functionality for MQTT-specified data types.
-use crate::{QoS, properties::Property, varint::Varint};
-use serde::ser::SerializeStruct;
+use crate::{properties::Property, varint::Varint, QoS};
 use bit_field::BitField;
+use serde::ser::SerializeStruct;
 use serde::Serialize;
 
 /// A wrapper type for a number of MQTT `Property`s.
@@ -188,10 +188,11 @@ impl SubscriptionOptions {
 
 impl serde::Serialize for SubscriptionOptions {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let value = *0u8.set_bits(0..2, self.maximum_qos as u8)
-                        .set_bit(2, self.no_local)
-                        .set_bit(3, self.retain_as_published)
-                        .set_bits(4..6, self.retain_behavior as u8);
+        let value = *0u8
+            .set_bits(0..2, self.maximum_qos as u8)
+            .set_bit(2, self.no_local)
+            .set_bit(3, self.retain_as_published)
+            .set_bits(4..6, self.retain_behavior as u8);
         serializer.serialize_u8(value)
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,8 +70,7 @@ fn main() -> std::io::Result<()> {
 
         if !subscribed {
             if client.is_connected() {
-                client.subscribe("response", &[]).unwrap();
-                client.subscribe("request", &[]).unwrap();
+                client.subscribe(&["response".into(), "request".into()], &[]).unwrap();
                 subscribed = true;
             }
         } else if !client.subscriptions_pending() && !published {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,7 +70,9 @@ fn main() -> std::io::Result<()> {
 
         if !subscribed {
             if client.is_connected() {
-                client.subscribe(&["response".into(), "request".into()], &[]).unwrap();
+                client
+                    .subscribe(&["response".into(), "request".into()], &[])
+                    .unwrap();
                 subscribed = true;
             }
         } else if !client.subscriptions_pending() && !published {

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -35,7 +35,7 @@ fn main() -> std::io::Result<()> {
         }
 
         if !subscribed {
-            mqtt.client().subscribe("data", &[]).unwrap();
+            mqtt.client().subscribe(&["data".into()], &[]).unwrap();
             subscribed = true;
         }
 


### PR DESCRIPTION
This PR fixes #98 by allowing for a list of `TopicFilter` objects to be provided to the `subscribe()` function. Each `TopicFilter` is composed of `SubscriptionOptions` and an `topic` path. Convenience `From<&str>` has been implemented for `TopicFilter` to allow the user to subscribe similar to the previous API.

@jordens There's some nuance in allowing the user to specify multiple TopicFilters per subscription request that ripples through the codebase. Let me know what you think about the change. We don't have to support multiple `TopicFilter`s per `SUBSCRIBE` if we don't want to.