### PR TITLE
Adding `QoS::AtLeastOnce` subscription support, updating property management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ the `poll()` closure executes on an inbound `Publish` message.
 * `subscribe()` now supports subscription configuration, such as retain configuration, QoS
   specification, and no-local publications.
 * `subscribe()` modified to take a list of topic filters.
+* Subscriptions at QoS::AtLeastOnce are now supported.
 
 ## Changed
 * [breaking] The client is no longer publicly exposed, and is instead accessible via `Minimq::client()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ the `poll()` closure executes on an inbound `Publish` message.
 * [breaking] Properties are now wrapped in MQTT-specific data types.
 * [breaking] Packets now support reason codes. Unused error codes were removed.
 * `poll()` updated such that the user should call it repeatedly until it returns `Ok(None)`.
+* [breaking] Property handling has been changed such that an arbitrary number can be received.
+  Properties are deserialized as needed by the application.
 
 ## Fixed
 * All unacknowledged messages will be guaranteed to be retransmitted upon connection with the

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ aren't:
 * Message publication is supported for all quality-of-service (QoS) levels
 * Message subscription is only supported for the following QoS levels:
     1. At Most once (Level 0)
+    2. At Least Once (Level 1)
 * Topic aliasing is not yet supported
 
 If there are features that you would like to have that are not yet supported, we are always

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,4 +1,4 @@
-mod deserializer;
+pub(crate) mod deserializer;
 mod packet_reader;
 pub mod received_packet;
 pub use deserializer::Error;

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -132,6 +132,7 @@ mod test {
 
     #[test]
     fn deserialize_good_connack() {
+        env_logger::init();
         let serialized_connack: [u8; 5] = [
             0x20, 0x03, // Remaining length = 3 bytes
             0x00, // Connect acknowledge flags - bit 0 clear.
@@ -151,7 +152,6 @@ mod test {
 
     #[test]
     fn deserialize_good_publish() {
-        env_logger::init();
         let serialized_publish: [u8; 7] = [
             0x30, // Publish, no QoS
             0x05, // Remaining length
@@ -185,7 +185,6 @@ mod test {
             ReceivedPacket::PubAck(pub_ack) => {
                 assert_eq!(pub_ack.reason.code(), ReasonCode::NoMatchingSubscribers);
                 assert_eq!(pub_ack.packet_identifier, 5);
-                assert_eq!(pub_ack.reason.properties().len(), 0);
             }
             _ => panic!("Invalid message"),
         }
@@ -259,7 +258,6 @@ mod test {
             ReceivedPacket::PubComp(comp) => {
                 assert_eq!(comp.packet_id, 5);
                 assert_eq!(comp.reason.code(), ReasonCode::PacketIdNotFound);
-                assert_eq!(comp.reason.properties().len(), 0);
             }
             _ => panic!("Invalid message"),
         }
@@ -298,7 +296,6 @@ mod test {
             ReceivedPacket::PubRec(rec) => {
                 assert_eq!(rec.packet_id, 5);
                 assert_eq!(rec.reason.code(), ReasonCode::NoMatchingSubscribers);
-                assert_eq!(rec.reason.properties().len(), 0);
             }
             _ => panic!("Invalid message"),
         }

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -1,8 +1,8 @@
 use crate::{
     message_types::MessageType,
     packets::{ConnAck, Disconnect, Pub, PubAck, PubComp, PubRec, SubAck},
-    varint::Varint,
     reason_codes::ReasonCode,
+    varint::Varint,
     ProtocolError, QoS, Retain,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 mod de;
 mod ser;
 
+mod design_parameters;
 mod message_types;
 pub mod mqtt_client;
 mod network_manager;
@@ -70,7 +71,6 @@ mod session_state;
 pub mod types;
 mod varint;
 mod will;
-mod design_parameters;
 
 pub use properties::Property;
 pub use reason_codes::ReasonCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,6 @@ pub const MQTT_SECURE_DEFAULT_PORT: u16 = 8883;
 /// The maximum number of subscriptions supported in a single request.
 pub const MAX_TOPICS_PER_SUBSCRIPTION: usize = 8;
 
-/// The maximum number of properties that can be received in a single message.
-pub const MAX_RX_PROPERTIES: usize = 8;
-
 /// The quality-of-service for an MQTT message.
 #[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive, PartialOrd)]
 #[repr(u8)]

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -71,7 +71,7 @@ pub struct ConnAck<'a> {
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Pub<'a> {
     /// The topic that the message was received on.
     pub topic: Utf8String<'a>,
@@ -86,30 +86,16 @@ pub struct Pub<'a> {
     pub payload: &'a [u8],
 
     /// Specifies whether or not the message should be retained on the broker.
+    #[serde(skip)]
     pub retain: Retain,
 
     /// Specifies the quality-of-service of the transmission.
+    #[serde(skip)]
     pub qos: QoS,
 
     /// Specified true if this message is a duplicate (e.g. it has already been transmitted).
+    #[serde(skip)]
     pub dup: bool,
-}
-
-impl<'a> serde::Serialize for Pub<'a> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut item = serializer.serialize_struct("Publish", 0)?;
-        item.serialize_field("topic", &self.topic)?;
-
-        // Packet identifiers are absent unless a QoS requiring IDs is specified.
-        if self.qos > QoS::AtMostOnce {
-            item.serialize_field("packet_identifier", self.packet_id.as_ref().unwrap())?;
-        }
-
-        item.serialize_field("properties", &self.properties)?;
-        item.serialize_field("payload", self.payload)?;
-
-        item.end()
-    }
 }
 
 /// An MQTT SUBSCRIBE control packet

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -68,7 +68,7 @@ pub struct ConnAck<'a> {
 
     /// A list of properties associated with the connection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
@@ -81,7 +81,7 @@ pub struct Pub<'a> {
     pub packet_id: Option<u16>,
 
     /// The properties transmitted with the publish data.
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 
     /// The message to be transmitted.
     pub payload: &'a [u8],
@@ -135,7 +135,7 @@ pub struct PingReq;
 pub struct PingResp;
 
 /// An MQTT PUBACK control packet
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PubAck<'a> {
     /// The ID of the packet being acknowledged.
     pub packet_identifier: u16,
@@ -153,11 +153,11 @@ pub struct SubAck<'a> {
 
     /// The optional properties associated with the acknowledgement.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 
     /// The response status code of the subscription request.
     #[serde(skip)]
-    pub codes: Vec<ReasonCode, {crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION}>,
+    pub codes: Vec<ReasonCode, { crate::design_parameters::MAX_TOPICS_PER_SUBSCRIPTION }>,
 }
 
 /// An MQTT PUBREC control packet
@@ -203,14 +203,25 @@ pub struct Disconnect<'a> {
 
     /// Properties associated with the disconnection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 }
 
 /// Success information for a control packet with optional data.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Reason<'a> {
     #[serde(borrow)]
     reason: Option<ReasonData<'a>>,
+}
+
+impl<'a> From<ReasonCode> for Reason<'a> {
+    fn from(code: ReasonCode) -> Self {
+        Self {
+            reason: Some(ReasonData {
+                code,
+                _properties: Vec::new(),
+            }),
+        }
+    }
 }
 
 impl<'a> Reason<'a> {
@@ -232,14 +243,14 @@ impl<'a> Reason<'a> {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct ReasonData<'a> {
     /// Reason code
     pub code: ReasonCode,
 
     /// The properties transmitted with the publish data.
     #[serde(borrow)]
-    pub _properties: Vec<Property<'a>, {crate::design_parameters::MAX_RX_PROPERTIES}>,
+    pub _properties: Vec<Property<'a>, { crate::design_parameters::MAX_RX_PROPERTIES }>,
 }
 
 #[cfg(test)]

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1,5 +1,4 @@
 use crate::{
-    properties::Property,
     reason_codes::ReasonCode,
     types::{Properties, TopicFilter, Utf8String},
     will::Will,
@@ -68,7 +67,7 @@ pub struct ConnAck<'a> {
 
     /// A list of properties associated with the connection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
+    pub properties: Properties<'a>,
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
@@ -81,7 +80,7 @@ pub struct Pub<'a> {
     pub packet_id: Option<u16>,
 
     /// The properties transmitted with the publish data.
-    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
+    pub properties: Properties<'a>,
 
     /// The message to be transmitted.
     pub payload: &'a [u8],
@@ -106,7 +105,7 @@ impl<'a> serde::Serialize for Pub<'a> {
             item.serialize_field("packet_identifier", self.packet_id.as_ref().unwrap())?;
         }
 
-        item.serialize_field("properties", &Properties(self.properties.as_slice()))?;
+        item.serialize_field("properties", &self.properties)?;
         item.serialize_field("payload", self.payload)?;
 
         item.end()
@@ -153,7 +152,7 @@ pub struct SubAck<'a> {
 
     /// The optional properties associated with the acknowledgement.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
+    pub properties: Properties<'a>,
 
     /// The response status code of the subscription request.
     #[serde(skip)]
@@ -203,7 +202,7 @@ pub struct Disconnect<'a> {
 
     /// Properties associated with the disconnection.
     #[serde(borrow)]
-    pub properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
+    pub properties: Properties<'a>,
 }
 
 /// Success information for a control packet with optional data.
@@ -218,7 +217,7 @@ impl<'a> From<ReasonCode> for Reason<'a> {
         Self {
             reason: Some(ReasonData {
                 code,
-                _properties: Vec::new(),
+                _properties: Properties::Slice(&[]),
             }),
         }
     }
@@ -232,15 +231,6 @@ impl<'a> Reason<'a> {
             .map(|data| data.code)
             .unwrap_or(ReasonCode::Success)
     }
-
-    /// Get the properties assocaited with the packet.
-    #[cfg(test)]
-    pub fn properties(&self) -> &'_ [Property<'a>] {
-        match &self.reason {
-            Some(ReasonData { _properties, .. }) => _properties,
-            _ => &[],
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -250,7 +240,7 @@ struct ReasonData<'a> {
 
     /// The properties transmitted with the publish data.
     #[serde(borrow)]
-    pub _properties: Vec<Property<'a>, { crate::MAX_RX_PROPERTIES }>,
+    pub _properties: Properties<'a>,
 }
 
 #[cfg(test)]
@@ -272,7 +262,7 @@ mod tests {
             qos: crate::QoS::AtMostOnce,
             packet_id: None,
             dup: false,
-            properties: heapless::Vec::new(),
+            properties: crate::types::Properties::Slice(&[]),
             retain: crate::Retain::NotRetained,
             topic: crate::types::Utf8String("ABC"),
             payload: &[0xAB, 0xCD],
@@ -300,7 +290,7 @@ mod tests {
             topic: crate::types::Utf8String("ABC"),
             packet_id: Some(0xBEEF),
             dup: false,
-            properties: heapless::Vec::new(),
+            properties: crate::types::Properties::Slice(&[]),
             retain: crate::Retain::NotRetained,
             payload: &[0xAB, 0xCD],
         };
@@ -324,7 +314,7 @@ mod tests {
 
         let subscribe = crate::packets::Subscribe {
             packet_id: 16,
-            properties: crate::types::Properties(&[]),
+            properties: crate::types::Properties::Slice(&[]),
             topics: &["ABC".into()],
         };
 
@@ -350,10 +340,9 @@ mod tests {
             topic: crate::types::Utf8String("ABC"),
             packet_id: None,
             dup: false,
-            properties: heapless::Vec::from_slice(&[crate::properties::Property::ResponseTopic(
-                crate::types::Utf8String("A"),
-            )])
-            .unwrap(),
+            properties: crate::types::Properties::Slice(&[
+                crate::properties::Property::ResponseTopic(crate::types::Utf8String("A")),
+            ]),
             retain: crate::Retain::NotRetained,
             payload: &[0xAB, 0xCD],
         };
@@ -381,7 +370,7 @@ mod tests {
             client_id: crate::types::Utf8String("ABC"),
             will: None,
             keep_alive: 10,
-            properties: crate::types::Properties(&[]),
+            properties: crate::types::Properties::Slice(&[]),
             clean_start: true,
         };
 
@@ -426,7 +415,7 @@ mod tests {
         let connect = crate::packets::Connect {
             clean_start: true,
             keep_alive: 10,
-            properties: crate::types::Properties(&[]),
+            properties: crate::types::Properties::Slice(&[]),
             client_id: crate::types::Utf8String("ABC"),
             will: Some(&will),
         };
@@ -462,13 +451,41 @@ mod tests {
         let pubrel = crate::packets::PubRel {
             packet_id: 5,
             code: ReasonCode::NoMatchingSubscribers,
-            properties: crate::types::Properties(&[]),
+            properties: crate::types::Properties::Slice(&[]),
         };
 
         let mut buffer: [u8; 1024] = [0; 1024];
         assert_eq!(
             MqttSerializer::to_buffer(&mut buffer, pubrel).unwrap(),
             good_pubrel
+        );
+    }
+
+    #[test]
+    fn serialize_puback() {
+        let good_puback: [u8; 6] = [
+            4 << 4, // PubAck
+            0x04,   // Remaining length
+            0x00,
+            0x15, // Identifier
+            0x00, // Response Code
+            0x00, // Properties length
+        ];
+
+        let pubrel = crate::packets::PubAck {
+            packet_identifier: 0x15,
+            reason: crate::packets::Reason {
+                reason: Some(crate::packets::ReasonData {
+                    code: ReasonCode::Success,
+                    _properties: crate::types::Properties::Slice(&[]),
+                }),
+            },
+        };
+
+        let mut buffer: [u8; 1024] = [0; 1024];
+        assert_eq!(
+            MqttSerializer::to_buffer(&mut buffer, pubrel).unwrap(),
+            good_puback
         );
     }
 }

--- a/src/reply_options.rs
+++ b/src/reply_options.rs
@@ -1,4 +1,7 @@
-use crate::{properties::Property, types::BinaryData};
+use crate::{
+    properties::Property,
+    types::{BinaryData, Properties},
+};
 
 /// Used to specify information about replies to received MQTT messages.
 pub struct ReplyOptions<'a> {
@@ -17,10 +20,10 @@ impl<'a> ReplyOptions<'a> {
     ///
     /// # Args
     /// * `properties` - The properties of the message being replied to.
-    pub fn new(properties: &[Property<'a>]) -> Self {
+    pub fn new(properties: &'a Properties<'a>) -> Self {
         // First, extract the response topic from the inbound properties.
-        let response_topic = properties.iter().find_map(|p| {
-            if let Property::ResponseTopic(topic) = p {
+        let response_topic = properties.into_iter().find_map(|p| {
+            if let Ok(Property::ResponseTopic(topic)) = p {
                 Some(topic.0)
             } else {
                 None
@@ -28,9 +31,9 @@ impl<'a> ReplyOptions<'a> {
         });
 
         // Next, copy over any correlation data to the outbound properties.
-        let correlation_data = properties.iter().find_map(|p| {
-            if let Property::CorrelationData(data) = p {
-                Some(*data)
+        let correlation_data = properties.into_iter().find_map(|p| {
+            if let Ok(Property::CorrelationData(data)) = p {
+                Some(data)
             } else {
                 None
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,17 +1,71 @@
 //! MQTT-Specific Data Types
 //!
 //! This module provides wrapper methods and serde functionality for MQTT-specified data types.
-use crate::{properties::Property, varint::Varint, QoS};
+use crate::{
+    de::deserializer::MqttDeserializer, properties::Property, varint::Varint, ProtocolError, QoS,
+};
 use bit_field::BitField;
 use serde::ser::SerializeStruct;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-/// A wrapper type for a number of MQTT `Property`s.
-///
-/// # Note
-/// This wrapper type is primarily used to support custom serialization.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Properties<'a>(pub &'a [Property<'a>]);
+#[derive(Debug, PartialEq)]
+pub enum Properties<'a> {
+    /// Properties ready for transmission are provided as a list of properties that will be later
+    /// encoded into a packet.
+    Slice(&'a [Property<'a>]),
+
+    /// Properties have an unknown size when being received. As such, we store them as a binary
+    /// blob that we iterate across.
+    DataBlock(&'a [u8]),
+}
+
+pub struct PropertiesIter<'a> {
+    props: &'a Properties<'a>,
+    index: usize,
+}
+
+impl<'a> core::iter::Iterator for PropertiesIter<'a> {
+    type Item = Result<Property<'a>, ProtocolError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.props {
+            Properties::Slice(props) => {
+                if self.index >= props.len() {
+                    return None;
+                }
+
+                let next_item = props[self.index];
+                self.index += 1;
+                Some(Ok(next_item))
+            }
+
+            Properties::DataBlock(data) => {
+                if self.index >= data.len() {
+                    return None;
+                }
+
+                // Progressively deserialize properties and yield them.
+                let mut deserializer = MqttDeserializer::new(&data[self.index..]);
+                let property = Property::deserialize(&mut deserializer)
+                    .map_err(ProtocolError::Deserialization);
+                self.index += deserializer.deserialized_bytes();
+                Some(property)
+            }
+        }
+    }
+}
+
+impl<'a> core::iter::IntoIterator for &'a Properties<'a> {
+    type Item = Result<Property<'a>, ProtocolError>;
+    type IntoIter = PropertiesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        PropertiesIter {
+            props: self,
+            index: 0,
+        }
+    }
+}
 
 impl<'a> serde::Serialize for Properties<'a> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -19,10 +73,40 @@ impl<'a> serde::Serialize for Properties<'a> {
 
         // Properties in MQTTv5 must be prefixed with a variable-length integer denoting the size
         // of the all of the properties in bytes.
-        let property_length: usize = self.0.iter().map(|prop| prop.size()).sum();
-        item.serialize_field("_len", &Varint(property_length as u32))?;
-        item.serialize_field("_props", self.0)?;
+        match self {
+            Properties::Slice(props) => {
+                let property_length: usize = props.iter().map(|prop| prop.size()).sum();
+                item.serialize_field("_len", &Varint(property_length as u32))?;
+                item.serialize_field("_props", props)?;
+            }
+            Properties::DataBlock(block) => {
+                item.serialize_field("_len", &Varint(block.len() as u32))?;
+                item.serialize_field("_data", block)?;
+            }
+        }
+
         item.end()
+    }
+}
+
+struct PropertiesVisitor;
+
+impl<'de> serde::de::Visitor<'de> for PropertiesVisitor {
+    type Value = Properties<'de>;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(formatter, "Properties")
+    }
+
+    fn visit_seq<S: serde::de::SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
+        let data = seq.next_element()?;
+        Ok(Properties::DataBlock(data.unwrap_or(&[])))
+    }
+}
+
+impl<'a, 'de: 'a> serde::de::Deserialize<'de> for Properties<'a> {
+    fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(PropertiesVisitor)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,9 @@
 //! MQTT-Specific Data Types
 //!
 //! This module provides wrapper methods and serde functionality for MQTT-specified data types.
-use crate::{QoS, properties::Property, varint::Varint};
-use serde::ser::SerializeStruct;
+use crate::{properties::Property, varint::Varint, QoS};
 use bit_field::BitField;
+use serde::ser::SerializeStruct;
 use serde::Serialize;
 
 /// A wrapper type for a number of MQTT `Property`s.
@@ -162,7 +162,7 @@ impl SubscriptionOptions {
     /// Specify the maximum QoS supported on this subscription.
     pub fn maximum_qos(mut self, qos: QoS) -> Self {
         // TODO: Support for higher QoS levels.
-        assert!(qos == QoS::AtMostOnce);
+        assert!(qos != QoS::ExactlyOnce);
         self.maximum_qos = qos;
         self
     }
@@ -188,10 +188,11 @@ impl SubscriptionOptions {
 
 impl serde::Serialize for SubscriptionOptions {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let value = *0u8.set_bits(0..2, self.maximum_qos as u8)
-                        .set_bit(2, self.no_local)
-                        .set_bit(3, self.retain_as_published)
-                        .set_bits(4..6, self.retain_behavior as u8);
+        let value = *0u8
+            .set_bits(0..2, self.maximum_qos as u8)
+            .set_bit(2, self.no_local)
+            .set_bit(3, self.retain_as_published)
+            .set_bits(4..6, self.retain_behavior as u8);
         serializer.serialize_u8(value)
     }
 }

--- a/src/will.rs
+++ b/src/will.rs
@@ -49,7 +49,7 @@ impl<const MSG_SIZE: usize> Will<MSG_SIZE> {
 
         let will_data = WillMessage {
             topic: Utf8String(topic),
-            properties: Properties(properties),
+            properties: Properties::Slice(properties),
             data: BinaryData(data),
         };
 

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -1,0 +1,68 @@
+use minimq::{Minimq, QoS, Retain, types::{SubscriptionOptions, TopicFilter}};
+
+use embedded_nal::{self, IpAddr, Ipv4Addr};
+use std_embedded_time::StandardClock;
+
+#[test]
+fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    let stack = std_embedded_nal::Stack::default();
+    let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let mut mqtt =
+        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+
+    // Use a keepalive interval for the client.
+    mqtt.client().set_keepalive_interval(60).unwrap();
+
+    let mut published = false;
+    let mut subscribed = false;
+    let mut received_messages = 0;
+
+    loop {
+        // Continually process the client until no more data is received.
+        while let Some(count) = mqtt
+            .poll(|_client, _topic, _payload, _properties| {1})
+            .unwrap()
+        {
+            received_messages += count;
+        }
+
+        if !mqtt.client().is_connected() {
+            continue;
+        }
+
+        if !subscribed {
+            let topic_filter = TopicFilter::new("data")
+                                    .options(SubscriptionOptions::default()
+                                             .maximum_qos(QoS::AtLeastOnce));
+            mqtt.client().subscribe(&[topic_filter], &[]).unwrap();
+            subscribed = true;
+        }
+
+        if mqtt.client().subscriptions_pending() {
+            continue;
+        }
+
+        if !published && mqtt.client().can_publish(QoS::AtLeastOnce) {
+            mqtt.client()
+                .publish(
+                    "data",
+                    "Ping".as_bytes(),
+                    QoS::AtLeastOnce,
+                    Retain::NotRetained,
+                    &[],
+                )
+                .unwrap();
+            log::info!("Publishing message");
+            published = true;
+        }
+
+        if received_messages > 0 {
+            assert!(published);
+            assert!(mqtt.client().pending_messages(QoS::AtLeastOnce) == 0);
+            log::info!("Reception Complete");
+            std::process::exit(0);
+        }
+    }
+}

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -1,4 +1,7 @@
-use minimq::{Minimq, QoS, Retain, types::{SubscriptionOptions, TopicFilter}};
+use minimq::{
+    types::{SubscriptionOptions, TopicFilter},
+    Minimq, QoS, Retain,
+};
 
 use embedded_nal::{self, IpAddr, Ipv4Addr};
 use std_embedded_time::StandardClock;
@@ -22,7 +25,7 @@ fn main() -> std::io::Result<()> {
     loop {
         // Continually process the client until no more data is received.
         while let Some(count) = mqtt
-            .poll(|_client, _topic, _payload, _properties| {1})
+            .poll(|_client, _topic, _payload, _properties| 1)
             .unwrap()
         {
             received_messages += count;
@@ -34,8 +37,7 @@ fn main() -> std::io::Result<()> {
 
         if !subscribed {
             let topic_filter = TopicFilter::new("data")
-                                    .options(SubscriptionOptions::default()
-                                             .maximum_qos(QoS::AtLeastOnce));
+                .options(SubscriptionOptions::default().maximum_qos(QoS::AtLeastOnce));
             mqtt.client().subscribe(&[topic_filter], &[]).unwrap();
             subscribed = true;
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -70,7 +70,9 @@ fn main() -> std::io::Result<()> {
 
         if !subscribed {
             if client.is_connected() {
-                client.subscribe(&["response".into(), "request".into()], &[]).unwrap();
+                client
+                    .subscribe(&["response".into(), "request".into()], &[])
+                    .unwrap();
                 subscribed = true;
             }
         } else if !client.subscriptions_pending() && !published {


### PR DESCRIPTION
This PR adds support for subscribing at `AtLeastOnce` QoS levels.

This PR addresses parts of https://github.com/quartiq/minimq/issues/62.

This PR also refactors the way in which properties are received. Instead of receiving and deserializing all properties immediately, the binary block of properties is instead read and deserialization is deferred until later. This allows the implementation to receive arbitrary numbers of properties.