### PR TITLE
Removing arbitrary limit on subscription topic count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,6 @@ pub const MQTT_INSECURE_DEFAULT_PORT: u16 = 1883;
 /// See [IANA Port Numbers](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt)
 pub const MQTT_SECURE_DEFAULT_PORT: u16 = 8883;
 
-/// The maximum number of subscriptions supported in a single request.
-pub const MAX_TOPICS_PER_SUBSCRIPTION: usize = 8;
-
 /// The quality-of-service for an MQTT message.
 #[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive, PartialOrd)]
 #[repr(u8)]
@@ -184,7 +181,6 @@ pub enum Error<E> {
     Protocol(ProtocolError),
     SessionReset,
     Clock(embedded_time::clock::Error),
-    TooManyTopics,
 }
 
 impl<E> From<embedded_time::clock::Error> for Error<E> {

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -73,7 +73,11 @@ where
             Some(index) => self.session_state.pending_subscriptions.swap_remove(index),
         };
 
-        for code in subscribe_acknowledge.codes.iter() {
+        for code in subscribe_acknowledge
+            .codes
+            .iter()
+            .map(|&x| ReasonCode::from(x))
+        {
             code.as_result()?;
         }
 
@@ -264,12 +268,6 @@ impl<
     ) -> Result<(), Error<TcpStack::Error>> {
         if !self.is_connected() {
             return Err(Error::NotReady);
-        }
-
-        // We can only support so many received response codes. As such, make sure that we don't
-        // allow too many concurrent topics.
-        if topics.len() > crate::MAX_TOPICS_PER_SUBSCRIPTION {
-            return Err(Error::TooManyTopics);
         }
 
         // We can't subscribe if there's a pending write in the network.

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -74,7 +74,7 @@ where
         };
 
         for &code in subscribe_acknowledge.codes.iter() {
-            ReasonCode::from(x).as_result()?;
+            ReasonCode::from(code).as_result()?;
         }
 
         Ok(())

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -73,12 +73,8 @@ where
             Some(index) => self.session_state.pending_subscriptions.swap_remove(index),
         };
 
-        for code in subscribe_acknowledge
-            .codes
-            .iter()
-            .map(|&x| ReasonCode::from(x))
-        {
-            code.as_result()?;
+        for &code in subscribe_acknowledge.codes.iter() {
+            ReasonCode::from(x).as_result()?;
         }
 
         Ok(())

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -5,7 +5,6 @@ use crate::{
     QoS, Retain,
 };
 use bit_field::BitField;
-use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use serde::ser::SerializeStruct;
@@ -142,7 +141,7 @@ pub struct SubAck<'a> {
 
     /// The response status code of the subscription request.
     #[serde(skip)]
-    pub codes: Vec<ReasonCode, { crate::MAX_TOPICS_PER_SUBSCRIPTION }>,
+    pub codes: &'a [u8],
 }
 
 /// An MQTT PUBREC control packet


### PR DESCRIPTION
This PR removes the arbitrary restriction on the maximum number of topics per subscription by instead just taking a slice to the subscription reason codes. These codes are then processed individually in the handler instead of being converted into ReasonCodes and pushed into a slice.