### PR TITLE
Fixing handling of puback property de/serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document describes the changes to Minimq between releases.
 
+# [Unreleased]
+
+## Fixed
+* `PubAck` can now be deserialized when no properties are present, but a reason code is specified.
+
 # [0.6.0] - 2022-11-03
 
 ## Added

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -203,6 +203,25 @@ mod test {
     }
 
     #[test]
+    fn deserialize_good_puback_without_properties() {
+        let serialized_puback: [u8; 5] = [
+            0x40, // PubAck
+            0x03, // Remaining length
+            0x00, 0x06, // Identifier
+            0x10, // ReasonCode
+        ];
+
+        let packet = ReceivedPacket::from_buffer(&serialized_puback).unwrap();
+        match packet {
+            ReceivedPacket::PubAck(pub_ack) => {
+                assert_eq!(pub_ack.packet_identifier, 6);
+                assert_eq!(pub_ack.reason.code(), ReasonCode::NoMatchingSubscribers);
+            }
+            _ => panic!("Invalid message"),
+        }
+    }
+
+    #[test]
     fn deserialize_good_suback() {
         let serialized_suback: [u8; 6] = [
             0x90, // SubAck

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -202,7 +202,7 @@ impl<'a> From<ReasonCode> for Reason<'a> {
         Self {
             reason: Some(ReasonData {
                 code,
-                _properties: Properties::Slice(&[]),
+                _properties: None,
             }),
         }
     }
@@ -225,7 +225,7 @@ struct ReasonData<'a> {
 
     /// The properties transmitted with the publish data.
     #[serde(borrow)]
-    pub _properties: Properties<'a>,
+    pub _properties: Option<Properties<'a>>,
 }
 
 #[cfg(test)]
@@ -448,13 +448,12 @@ mod tests {
 
     #[test]
     fn serialize_puback() {
-        let good_puback: [u8; 6] = [
+        let good_puback: [u8; 5] = [
             4 << 4, // PubAck
-            0x04,   // Remaining length
+            0x03,   // Remaining length
             0x00,
             0x15, // Identifier
             0x00, // Response Code
-            0x00, // Properties length
         ];
 
         let pubrel = crate::packets::PubAck {
@@ -462,7 +461,7 @@ mod tests {
             reason: crate::packets::Reason {
                 reason: Some(crate::packets::ReasonData {
                     code: ReasonCode::Success,
-                    _properties: crate::types::Properties::Slice(&[]),
+                    _properties: None,
                 }),
             },
         };


### PR DESCRIPTION
This PR fixes #115 by adjusting the deserialization and serialization of `PubAck` messages that have no properties.