### PR TITLE
Fixing user property serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document describes the changes to Minimq between releases.
 
+# [Unreleased]
+
+## Fixed
+* `UserProperty` now properly serializes key-then-value. Serialization order was previously
+  unintentionally inverted.
+
 # [0.6.1] - 2022-11-03
 
 ## Fixed

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -339,6 +339,38 @@ mod tests {
     }
 
     #[test]
+    pub fn serialize_publish_with_user_prop() {
+        let good_publish: [u8; 17] = [
+            0x30, // Publish message
+            0x0f, // Remaining length (15)
+            0x00, 0x03, 0x41, 0x42, 0x43, // Topic: ABC
+            0x07, // Properties length - 1 property encoding a string pair, each of length 1
+            0x26, 0x00, 0x01, 0x41, 0x00, 0x01, 0x42, // UserProperty("A", "B")
+            0xAB, 0xCD, // Payload
+        ];
+
+        let publish = crate::packets::Pub {
+            qos: crate::QoS::AtMostOnce,
+            topic: crate::types::Utf8String("ABC"),
+            packet_id: None,
+            dup: false,
+            properties: crate::types::Properties::Slice(&[
+                crate::properties::Property::UserProperty(
+                    crate::types::Utf8String("A"),
+                    crate::types::Utf8String("B"),
+                ),
+            ]),
+            retain: crate::Retain::NotRetained,
+            payload: &[0xAB, 0xCD],
+        };
+
+        let mut buffer: [u8; 900] = [0; 900];
+        let message = MqttSerializer::to_buffer(&mut buffer, &publish).unwrap();
+
+        assert_eq!(message, good_publish);
+    }
+
+    #[test]
     fn serialize_connect() {
         let good_serialized_connect: [u8; 18] = [
             0x10, // Connect

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -274,8 +274,8 @@ impl<'a> serde::Serialize for Property<'a> {
             Property::MaximumQoS(data) => serializer.serialize_element(data)?,
             Property::RetainAvailable(data) => serializer.serialize_element(data)?,
             Property::UserProperty(key, value) => {
-                serializer.serialize_element(value)?;
                 serializer.serialize_element(key)?;
+                serializer.serialize_element(value)?;
             }
             Property::MaximumPacketSize(data) => serializer.serialize_element(data)?,
             Property::WildcardSubscriptionAvailable(data) => serializer.serialize_element(data)?,


### PR DESCRIPTION
This PR fixes #122 by correcting serialization of `UserProperty` properties. Previously, the key and value order were inverted.