### PR TITLE
Preparing for a 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This document describes the changes to Minimq between releases.
 
 # [Unreleased]
 
+# [0.6.2] - 2023-04-05
+
 ## Fixed
 * `UserProperty` now properly serializes key-then-value. Serialization order was previously
   unintentionally inverted.
@@ -111,7 +113,8 @@ keep-alive interval
 
 * Initial library release and publish to crates.io
 
-[Unreleased]: https://github.com/quartiq/minimq/compare/0.6.1...HEAD
+[Unreleased]: https://github.com/quartiq/minimq/compare/0.6.2...HEAD
+[0.6.2]: https://github.com/quartiq/minimq/releases/tag/0.6.2
 [0.6.1]: https://github.com/quartiq/minimq/releases/tag/0.6.1
 [0.6.0]: https://github.com/quartiq/minimq/releases/tag/0.6.0
 [0.5.3]: https://github.com/quartiq/minimq/releases/tag/0.5.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimq"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>", "Max Rottenkolber <max@mr.gy>"]
 edition = "2018"
 


### PR DESCRIPTION
This PR prepares for a 0.6.2 release to patch up an issue with UserProperty serialization