### PR TITLE
Preparing for 0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This document describes the changes to Minimq between releases.
 
-# [Unreleased]
+# [0.7.0] - 2023-06-22
 
 ## Fixed
 * [breaking] Embedded-nal version updated to 0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimq"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>", "Max Rottenkolber <max@mr.gy>"]
 edition = "2018"
 


### PR DESCRIPTION
Preps for a 0.7.0 release of minimq so we can deploy connectivity fixes.