### PR TITLE
Using user-supplied RX and TX buffers, removing const-generics

### DIFF
--- a/src/de/packet_reader.rs
+++ b/src/de/packet_reader.rs
@@ -1,16 +1,16 @@
 use super::received_packet::ReceivedPacket;
 use crate::ProtocolError as Error;
 
-pub(crate) struct PacketReader<const T: usize> {
-    pub buffer: [u8; T],
+pub(crate) struct PacketReader<'a> {
+    pub buffer: &'a mut [u8],
     read_bytes: usize,
     packet_length: Option<usize>,
 }
 
-impl<const T: usize> PacketReader<T> {
-    pub fn new() -> PacketReader<T> {
+impl<'a> PacketReader<'a> {
+    pub fn new(buffer: &'a mut [u8]) -> PacketReader<'a> {
         PacketReader {
-            buffer: [0; T],
+            buffer,
             read_bytes: 0,
             packet_length: None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,15 @@
 //! // Messages are "in flight" if QoS::AtLeastOnce has not yet been acknowledged (PUBACK)
 //! // or QoS::ExactlyOnce has not been completed (PUBCOMP).
 //! // Connect to a broker at localhost - Use a client ID of "test".
+//! let mut rx_buffer = [0; 256];
+//! let mut tx_buffer = [0; 256];
 //! let mut mqtt: Minimq<_, _, 256, 16> = Minimq::new(
 //!         "127.0.0.1".parse().unwrap(),
 //!         "test",
 //!         std_embedded_nal::Stack::default(),
-//!         std_embedded_time::StandardClock::default()).unwrap();
+//!         std_embedded_time::StandardClock::default(),
+//!         &mut rx_buffer,
+//!         &mut tx_buffer).unwrap();
 //!
 //! let mut subscribed = false;
 //!
@@ -76,6 +80,7 @@ mod will;
 pub use properties::Property;
 pub use publication::Publication;
 pub use reason_codes::ReasonCode;
+pub use will::Will;
 
 pub use embedded_nal;
 pub use embedded_time;

--- a/src/message_types.rs
+++ b/src/message_types.rs
@@ -35,7 +35,7 @@ pub trait ControlPacket {
     }
 }
 
-impl<'a, const T: usize> ControlPacket for Connect<'a, T> {
+impl<'a> ControlPacket for Connect<'a> {
     const MESSAGE_TYPE: MessageType = MessageType::Connect;
 }
 

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -731,7 +731,7 @@ impl<
     }
 
     /// Directly access the MQTT client.
-    pub fn client(&mut self) -> &'buf mut MqttClient<TcpStack, Clock, MSG_SIZE, MSG_COUNT> {
+    pub fn client(&mut self) -> &mut MqttClient<'buf, TcpStack, Clock, MSG_SIZE, MSG_COUNT> {
         &mut self.client
     }
 }

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -7,30 +7,31 @@
 //! violating Rust's borrow rules.
 use crate::message_types::ControlPacket;
 use embedded_nal::{nb, SocketAddr, TcpClientStack, TcpError};
-use heapless::Vec;
 use serde::Serialize;
 
 use crate::Error;
 
 /// Simple structure for maintaining state of the network connection.
-pub(crate) struct InterfaceHolder<TcpStack: TcpClientStack, const MSG_SIZE: usize> {
+pub(crate) struct InterfaceHolder<'a, TcpStack: TcpClientStack> {
     socket: Option<TcpStack::TcpSocket>,
     network_stack: TcpStack,
-    pending_write: Option<Vec<u8, MSG_SIZE>>,
+    tx_buffer: &'a mut [u8],
+    pending_write: Option<(usize, usize)>,
     connection_died: bool,
 }
 
-impl<TcpStack, const MSG_SIZE: usize> InterfaceHolder<TcpStack, MSG_SIZE>
+impl<'a, TcpStack> InterfaceHolder<'a, TcpStack>
 where
     TcpStack: TcpClientStack,
 {
     /// Construct a new network holder utility.
-    pub fn new(stack: TcpStack) -> Self {
+    pub fn new(stack: TcpStack, tx_buffer: &'a mut [u8]) -> Self {
         Self {
             socket: None,
             network_stack: stack,
             pending_write: None,
             connection_died: false,
+            tx_buffer,
         }
     }
 
@@ -89,14 +90,14 @@ where
     ///
     /// # Args
     /// * `packet` - The data to write.
-    pub fn write(&mut self, data: &[u8]) -> Result<(), Error<TcpStack::Error>> {
+    fn commit_write(&mut self, start: usize, len: usize) -> Result<(), Error<TcpStack::Error>> {
         // If there's an unfinished write pending, it's invalid to try to write new data. The
         // previous write must first be completed.
         assert!(self.pending_write.is_none());
 
         let socket = self.socket.as_mut().ok_or(Error::NotReady)?;
         self.network_stack
-            .send(socket, data)
+            .send(socket, &self.tx_buffer[start..][..len])
             .or_else(|err| match err {
                 nb::Error::WouldBlock => Ok(0),
                 nb::Error::Other(err) if err.kind() == embedded_nal::TcpErrorKind::PipeClosed => {
@@ -106,13 +107,16 @@ where
                 nb::Error::Other(err) => Err(Error::Network(err)),
             })
             .map(|written| {
-                crate::trace!("Wrote: {:0x?}", &data[..written]);
-                if written != data.len() {
-                    // Note(unwrap): The packet should always be smaller than a single message.
-                    self.pending_write
-                        .replace(Vec::from_slice(&data[written..]).unwrap());
+                crate::trace!("Wrote: {:0x?}", &self.tx_buffer[..written]);
+                if written != len {
+                    self.pending_write.replace((written, len));
                 }
             })
+    }
+
+    pub fn write(&mut self, packet: &[u8]) -> Result<(), Error<TcpStack::Error>> {
+        self.tx_buffer.copy_from_slice(packet);
+        self.commit_write(0, packet.len())
     }
 
     /// Send an MQTT control packet over the interface.
@@ -122,19 +126,22 @@ where
     pub fn send_packet<T: Serialize + ControlPacket + core::fmt::Debug>(
         &mut self,
         packet: &T,
-    ) -> Result<(), Error<TcpStack::Error>> {
-        crate::info!("Sending: {:?}", packet);
-        let mut buffer: [u8; MSG_SIZE] = [0; MSG_SIZE];
-        let packet = crate::ser::MqttSerializer::to_buffer(&mut buffer, packet)?;
+    ) -> Result<&[u8], Error<TcpStack::Error>> {
+        // If there's an unfinished write pending, it's invalid to try to write new data. The
+        // previous write must first be completed.
+        assert!(self.pending_write.is_none());
 
-        self.write(packet)?;
-        Ok(())
+        crate::info!("Sending: {:?}", packet);
+        let len = crate::ser::MqttSerializer::to_buffer(self.tx_buffer, packet)?.len();
+
+        self.commit_write(0, len)?;
+        Ok(&self.tx_buffer[..len])
     }
 
     /// Finish writing an MQTT control packet to the interface if one exists.
     pub fn finish_write(&mut self) -> Result<(), Error<TcpStack::Error>> {
-        if let Some(ref packet) = self.pending_write.take() {
-            self.write(packet.as_slice())?;
+        if let Some((head, tail)) = self.pending_write.take() {
+            self.commit_write(head, tail - head)?;
         }
 
         Ok(())

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -11,7 +11,7 @@ use serde::ser::SerializeStruct;
 
 /// An MQTT CONNECT packet.
 #[derive(Debug)]
-pub struct Connect<'a, const T: usize> {
+pub struct Connect<'a> {
     /// Specifies the keep-alive interval of the connection in seconds.
     pub keep_alive: u16,
 
@@ -23,13 +23,13 @@ pub struct Connect<'a, const T: usize> {
     pub client_id: Utf8String<'a>,
 
     /// An optional will message to be transmitted whenever the connection is lost.
-    pub will: Option<&'a Will<T>>,
+    pub will: Option<&'a Will<'a>>,
 
     /// Specified true there is no session state being taken in to the MQTT connection.
     pub clean_start: bool,
 }
 
-impl<'a, const T: usize> serde::Serialize for Connect<'a, T> {
+impl<'a> serde::Serialize for Connect<'a> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut flags: u8 = 0;
         flags.set_bit(1, self.clean_start);
@@ -39,7 +39,7 @@ impl<'a, const T: usize> serde::Serialize for Connect<'a, T> {
             // the will message, and whether or not the will message should be retained.
             flags.set_bit(2, true);
             flags.set_bits(3..=4, will.qos as u8);
-            flags.set_bit(5, will.retain == Retain::Retained);
+            flags.set_bit(5, will.retained == Retain::Retained);
         }
 
         let mut item = serializer.serialize_struct("Connect", 0)?;
@@ -49,7 +49,11 @@ impl<'a, const T: usize> serde::Serialize for Connect<'a, T> {
         item.serialize_field("keep_alive", &self.keep_alive)?;
         item.serialize_field("properties", &self.properties)?;
         item.serialize_field("client_id", &self.client_id)?;
-        item.serialize_field("will", &self.will)?;
+
+        if let Some(will) = &self.will {
+            let flattened = will.flatten();
+            item.serialize_field("will", &flattened)?;
+        }
 
         item.end()
     }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -385,7 +385,7 @@ mod tests {
         ];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let connect: crate::packets::Connect<'_, 1> = crate::packets::Connect {
+        let connect: crate::packets::Connect<'_> = crate::packets::Connect {
             client_id: crate::types::Utf8String("ABC"),
             will: None,
             keep_alive: 10,
@@ -427,7 +427,7 @@ mod tests {
         ];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let mut will = crate::will::Will::<100>::new("EFG", &[0xAB, 0xCD], &[]).unwrap();
+        let mut will = crate::will::Will::new("EFG", &[0xAB, 0xCD], &[]).unwrap();
         will.qos(crate::QoS::AtMostOnce);
         will.retained(crate::Retain::NotRetained);
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -89,22 +89,29 @@ impl<'a> MqttSerializer<'a> {
     /// # Args
     /// * `buf` - The buffer to encode data into.
     /// * `packet` - The packet to encode.
+    pub fn to_buffer_meta<T: Serialize + ControlPacket>(
+        buf: &'a mut [u8],
+        packet: &T,
+    ) -> Result<(usize, &'a [u8]), Error> {
+        let mut serializer = Self::new(buf);
+        packet.serialize(&mut serializer)?;
+        let (offset, packet) = serializer.finalize(T::MESSAGE_TYPE, packet.fixed_header_flags())?;
+        Ok((offset, packet))
+    }
+
+    /// Encode an MQTT control packet into a buffer.
+    ///
+    /// # Args
+    /// * `buf` - The buffer to encode data into.
+    /// * `packet` - The packet to encode.
     pub fn to_buffer<T: Serialize + ControlPacket>(
         buf: &'a mut [u8],
         packet: &T,
     ) -> Result<&'a [u8], Error> {
         let mut serializer = Self::new(buf);
         packet.serialize(&mut serializer)?;
-        let packet = serializer.finalize(T::MESSAGE_TYPE, packet.fixed_header_flags())?;
+        let (_, packet) = serializer.finalize(T::MESSAGE_TYPE, packet.fixed_header_flags())?;
         Ok(packet)
-    }
-
-    /// Finish the packet without prepending the MQTT fixed header.
-    ///
-    /// # Returns
-    /// A slice representing the serialized packet without a fixed header.
-    pub fn finish_without_fixed_header(self) -> &'a [u8] {
-        &self.buf[MAX_FIXED_HEADER_SIZE..self.index]
     }
 
     /// Finalize the packet, prepending the MQTT fixed header.
@@ -115,7 +122,7 @@ impl<'a> MqttSerializer<'a> {
     ///
     /// # Returns
     /// A slice representing the serialized packet.
-    pub fn finalize(self, typ: MessageType, flags: u8) -> Result<&'a [u8], Error> {
+    pub fn finalize(self, typ: MessageType, flags: u8) -> Result<(usize, &'a [u8]), Error> {
         let len = self.index - MAX_FIXED_HEADER_SIZE;
 
         let mut buffer = VarintBuffer::new();
@@ -131,7 +138,8 @@ impl<'a> MqttSerializer<'a> {
         let header: u8 = *0u8.set_bits(4..8, typ as u8).set_bits(0..4, flags);
         self.buf[MAX_FIXED_HEADER_SIZE - buffer.data.len() - 1] = header;
 
-        Ok(&self.buf[MAX_FIXED_HEADER_SIZE - buffer.data.len() - 1..self.index])
+        let offset = MAX_FIXED_HEADER_SIZE - buffer.data.len() - 1;
+        Ok((offset, &self.buf[offset..self.index]))
     }
 
     /// Write data into the packet.

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -108,9 +108,7 @@ impl<'a> MqttSerializer<'a> {
         buf: &'a mut [u8],
         packet: &T,
     ) -> Result<&'a [u8], Error> {
-        let mut serializer = Self::new(buf);
-        packet.serialize(&mut serializer)?;
-        let (_, packet) = serializer.finalize(T::MESSAGE_TYPE, packet.fixed_header_flags())?;
+        let (_, packet) = Self::to_buffer_meta(buf, packet)?;
         Ok(packet)
     }
 

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -10,10 +10,19 @@ use std_embedded_time::StandardClock;
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
+    let mut rx_buffer = [0u8; 256];
+    let mut tx_buffer = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt =
-        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+    let mut mqtt = Minimq::<_, _, 256, 16>::new(
+        localhost,
+        "",
+        stack,
+        StandardClock::default(),
+        &mut rx_buffer,
+        &mut tx_buffer,
+    )
+    .unwrap();
 
     // Use a keepalive interval for the client.
     mqtt.client().set_keepalive_interval(60).unwrap();

--- a/tests/exactly_once_subscription.rs
+++ b/tests/exactly_once_subscription.rs
@@ -10,10 +10,19 @@ use std_embedded_time::StandardClock;
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
+    let mut rx_buffer = [0u8; 256];
+    let mut tx_buffer = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt =
-        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+    let mut mqtt = Minimq::<_, _, 256, 16>::new(
+        localhost,
+        "",
+        stack,
+        StandardClock::default(),
+        &mut rx_buffer,
+        &mut tx_buffer,
+    )
+    .unwrap();
 
     // Use a keepalive interval for the client.
     mqtt.client().set_keepalive_interval(60).unwrap();

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -7,10 +7,19 @@ use std_embedded_time::StandardClock;
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
+    let mut rx_buffer = [0u8; 256];
+    let mut tx_buffer = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt =
-        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+    let mut mqtt = Minimq::<_, _, 256, 16>::new(
+        localhost,
+        "",
+        stack,
+        StandardClock::default(),
+        &mut rx_buffer,
+        &mut tx_buffer,
+    )
+    .unwrap();
 
     // Use a keepalive interval for the client.
     mqtt.client().set_keepalive_interval(60).unwrap();

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -7,10 +7,19 @@ use std_embedded_time::StandardClock;
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
+    let mut rx_buffer = [0u8; 256];
+    let mut tx_buffer = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt =
-        Minimq::<_, _, 256, 16>::new(localhost, "", stack, StandardClock::default()).unwrap();
+    let mut mqtt = Minimq::<_, _, 256, 16>::new(
+        localhost,
+        "",
+        stack,
+        StandardClock::default(),
+        &mut rx_buffer,
+        &mut tx_buffer,
+    )
+    .unwrap();
 
     // Use a keepalive interval for the client.
     mqtt.client().set_keepalive_interval(60).unwrap();


### PR DESCRIPTION
This is a first stab at updating minimq to remove const generics and take the smoltcp path of user-supplied buffers. This should drastically cut down on stack and RAM usage for end users.

Fixes #112 