### PR TITLE
Adding support for authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ embedded-nal = "0.7"
 [features]
 default = []
 logging = ["log"]
+unsecure = []
 
 [dev-dependencies]
 log = "0.4"

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -208,6 +208,7 @@ impl<
     /// # Args
     /// * `user_name` - The user name
     /// * `password` - The password
+    #[cfg(feature = "unsecure")]
     pub fn set_auth(
         &mut self,
         user_name: &str,

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1,6 +1,6 @@
 use crate::{
     reason_codes::ReasonCode,
-    types::{Properties, TopicFilter, Utf8String},
+    types::{Properties, TopicFilter, Utf8String, Auth},
     will::Will,
     QoS, Retain,
 };
@@ -22,6 +22,9 @@ pub struct Connect<'a, const T: usize> {
     /// an ID from the broker.
     pub client_id: Utf8String<'a>,
 
+    /// An optional authentication message used by the server.
+    pub auth: Option<&'a Auth>,
+
     /// An optional will message to be transmitted whenever the connection is lost.
     pub will: Option<&'a Will<T>>,
 
@@ -42,6 +45,11 @@ impl<'a, const T: usize> serde::Serialize for Connect<'a, T> {
             flags.set_bit(5, will.retain == Retain::Retained);
         }
 
+        if self.auth.is_some() {
+            flags.set_bit(6, true);
+            flags.set_bit(7, true);
+        }
+        
         let mut item = serializer.serialize_struct("Connect", 0)?;
         item.serialize_field("protocol_name", &Utf8String("MQTT"))?;
         item.serialize_field("protocol_version", &5u8)?;
@@ -50,6 +58,10 @@ impl<'a, const T: usize> serde::Serialize for Connect<'a, T> {
         item.serialize_field("properties", &self.properties)?;
         item.serialize_field("client_id", &self.client_id)?;
         item.serialize_field("will", &self.will)?;
+        if let Some(auth) = &self.auth {
+            item.serialize_field("user_name", &Utf8String(auth.user_name.as_str()))?;
+            item.serialize_field("password", &Utf8String(auth.password.as_str()))?;
+        }
 
         item.end()
     }
@@ -385,6 +397,7 @@ mod tests {
         let mut buffer: [u8; 900] = [0; 900];
         let connect: crate::packets::Connect<'_, 1> = crate::packets::Connect {
             client_id: crate::types::Utf8String("ABC"),
+            auth: None,
             will: None,
             keep_alive: 10,
             properties: crate::types::Properties::Slice(&[]),
@@ -434,6 +447,7 @@ mod tests {
             keep_alive: 10,
             properties: crate::types::Properties::Slice(&[]),
             client_id: crate::types::Utf8String("ABC"),
+            auth: None,
             will: Some(&will),
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,8 @@ use bit_field::BitField;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
+use heapless::String;
+
 #[derive(Debug, PartialEq)]
 pub enum Properties<'a> {
     /// Properties ready for transmission are provided as a list of properties that will be later
@@ -165,6 +167,12 @@ impl<'de> serde::de::Deserialize<'de> for BinaryData<'de> {
     fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_bytes(BinaryDataVisitor)
     }
+}
+
+#[derive(Debug)]
+pub struct Auth {
+    pub user_name: String<64>,
+    pub password: String<64>,
 }
 
 /// A wrapper type for "UTF-8 Encoded Strings" as defined in the MQTT v5 specification.


### PR DESCRIPTION
Add a set_auth function to set the user name and password. I test with the version 0.7.0 and it works fine. Not sure if it compatible with the current version.
[issue 119](https://github.com/quartiq/minimq/issues/119)

Fixes #119 