### PR TITLE
Adding support for domain-named brokers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document describes the changes to Minimq between releases.
 
 ## Added
 * Support for subscribing at `QoS::ExactlyOnce`
+* Brokers may now be provided using domain-name syntax or static IP addresses.
 
 ## Fixed
 * Fixed an issue where PubComp was serialized with an incorrect control code

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -1,0 +1,77 @@
+use crate::MQTT_INSECURE_DEFAULT_PORT;
+use embedded_nal::{nb, AddrType, Dns, IpAddr, Ipv4Addr, SocketAddr};
+
+pub trait Broker {
+    fn get_address(&mut self) -> Option<SocketAddr>;
+    fn set_port(&mut self, port: u16);
+}
+
+pub struct NamedBroker<R: Dns> {
+    raw: &'static str,
+    resolver: R,
+    addr: SocketAddr,
+}
+
+impl<R: Dns> NamedBroker<R> {
+    pub fn new(broker: &'static str, resolver: R) -> Self {
+        let addr: Ipv4Addr = broker.parse().unwrap_or(Ipv4Addr::UNSPECIFIED);
+
+        Self {
+            raw: broker,
+            resolver,
+            addr: SocketAddr::new(IpAddr::V4(addr), MQTT_INSECURE_DEFAULT_PORT),
+        }
+    }
+}
+
+impl<R: Dns> Broker for NamedBroker<R> {
+    fn get_address(&mut self) -> Option<SocketAddr> {
+        // Attempt to resolve the address.
+        if !self.addr.ip().is_unspecified() {
+            match self.resolver.get_host_by_name(self.raw, AddrType::IPv4) {
+                Ok(ip) => self.addr.set_ip(ip),
+                Err(nb::Error::WouldBlock) => {}
+                other => {
+                    other.unwrap();
+                }
+            }
+        }
+
+        if !self.addr.ip().is_unspecified() {
+            Some(self.addr)
+        } else {
+            None
+        }
+    }
+
+    fn set_port(&mut self, port: u16) {
+        self.addr.set_port(port)
+    }
+}
+
+pub struct IpBroker {
+    addr: SocketAddr,
+}
+
+impl IpBroker {
+    pub fn new(broker: IpAddr) -> Self {
+        Self {
+            addr: SocketAddr::new(broker, MQTT_INSECURE_DEFAULT_PORT),
+        }
+    }
+}
+impl Broker for IpBroker {
+    fn get_address(&mut self) -> Option<SocketAddr> {
+        Some(self.addr)
+    }
+
+    fn set_port(&mut self, port: u16) {
+        self.addr.set_port(port)
+    }
+}
+
+impl From<IpAddr> for IpBroker {
+    fn from(addr: IpAddr) -> Self {
+        IpBroker::new(addr)
+    }
+}

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -27,7 +27,7 @@ impl<R: Dns> NamedBroker<R> {
 impl<R: Dns> Broker for NamedBroker<R> {
     fn get_address(&mut self) -> Option<SocketAddr> {
         // Attempt to resolve the address.
-        if !self.addr.ip().is_unspecified() {
+        if self.addr.ip().is_unspecified() {
             match self.resolver.get_host_by_name(self.raw, AddrType::IPv4) {
                 Ok(ip) => self.addr.set_ip(ip),
                 Err(nb::Error::WouldBlock) => {}

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -1,4 +1,4 @@
-use crate::MQTT_INSECURE_DEFAULT_PORT;
+use crate::{warn, MQTT_INSECURE_DEFAULT_PORT};
 use embedded_nal::{nb, AddrType, Dns, IpAddr, Ipv4Addr, SocketAddr};
 
 pub trait Broker {
@@ -31,8 +31,8 @@ impl<R: Dns> Broker for NamedBroker<R> {
             match self.resolver.get_host_by_name(self.raw, AddrType::IPv4) {
                 Ok(ip) => self.addr.set_ip(ip),
                 Err(nb::Error::WouldBlock) => {}
-                other => {
-                    other.unwrap();
+                Err(_other) => {
+                    warn!("DNS lookup failed: {_other:?}")
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,9 @@
 //! let mut rx_buffer = [0; 256];
 //! let mut tx_buffer = [0; 256];
 //! let mut session = [0; 256];
-//! let mut mqtt = Minimq::new(
-//!         "127.0.0.1".parse().unwrap(),
+//! let localhost: embedded_nal::IpAddr = "127.0.0.1".parse().unwrap();
+//! let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
+//!         localhost,
 //!         "test",
 //!         std_embedded_nal::Stack::default(),
 //!         std_embedded_time::StandardClock::default(),
@@ -64,8 +65,11 @@
 //! }
 //! ```
 
+pub mod broker;
 mod de;
 mod ser;
+
+pub use broker::Broker;
 
 mod message_types;
 pub mod mqtt_client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! let mut session = [0; 256];
 //! let localhost: embedded_nal::IpAddr = "127.0.0.1".parse().unwrap();
 //! let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-//!         localhost,
+//!         localhost.into(),
 //!         "test",
 //!         std_embedded_nal::Stack::default(),
 //!         std_embedded_time::StandardClock::default(),

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -740,7 +740,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
     /// A `Minimq` object that can be used for publishing messages, subscribing to topics, and
     /// managing the MQTT state.
     pub fn new(
-        broker: impl Into<Broker>,
+        broker: Broker,
         client_id: &str,
         network_stack: TcpStack,
         clock: Clock,
@@ -755,7 +755,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
         let minimq = Minimq {
             client: MqttClient {
                 sm: StateMachine::new(ClientContext::new(clock, session_state)),
-                broker: broker.into(),
+                broker,
                 will: None,
                 network: InterfaceHolder::new(network_stack, tx_buffer),
                 max_packet_size: rx_buffer.len(),

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -6,8 +6,7 @@ use crate::{
     session_state::SessionState,
     types::{Properties, TopicFilter, Utf8String},
     will::Will,
-    Error, MinimqError, Property, ProtocolError, QoS, MQTT_INSECURE_DEFAULT_PORT,
-    {debug, error, info, warn},
+    Error, MinimqError, Property, ProtocolError, QoS, {debug, error, info, warn},
 };
 
 use core::convert::TryInto;
@@ -16,7 +15,7 @@ use embedded_time::{
     Instant,
 };
 
-use embedded_nal::{IpAddr, SocketAddr, TcpClientStack};
+use embedded_nal::TcpClientStack;
 
 use heapless::String;
 
@@ -268,16 +267,21 @@ impl<E> From<sm::Error<MinimqError>> for Error<E> {
 }
 
 /// The client that can be used for interacting with the MQTT broker.
-pub struct MqttClient<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock> {
+pub struct MqttClient<
+    'buf,
+    TcpStack: TcpClientStack,
+    Clock: embedded_time::Clock,
+    Broker: crate::Broker,
+> {
     sm: sm::StateMachine<ClientContext<'buf, Clock>>,
     network: InterfaceHolder<'buf, TcpStack>,
     will: Option<Will<'buf>>,
-    broker: SocketAddr,
+    broker: Broker,
     max_packet_size: usize,
 }
 
-impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock>
-    MqttClient<'buf, TcpStack, Clock>
+impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate::Broker>
+    MqttClient<'buf, TcpStack, Clock, Broker>
 {
     /// Specify the Will message to be sent if the client disconnects.
     ///
@@ -538,9 +542,11 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock>
 
         match *self.sm.state() {
             States::Disconnected => {
-                if self.network.connect(self.broker)? {
-                    info!("TCP socket connected");
-                    self.sm.process_event(Events::TcpConnected)?;
+                if let Some(broker) = self.broker.get_address() {
+                    if self.network.connect(broker)? {
+                        info!("TCP socket connected");
+                        self.sm.process_event(Events::TcpConnected)?;
+                    }
                 }
             }
             States::Restart => self.handle_restart()?,
@@ -557,7 +563,12 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock>
         f: &mut F,
     ) -> Result<Option<T>, Error<TcpStack::Error>>
     where
-        F: FnMut(&mut MqttClient<'buf, TcpStack, Clock>, &'a str, &[u8], &Properties<'a>) -> T,
+        F: FnMut(
+            &mut MqttClient<'buf, TcpStack, Clock, Broker>,
+            &'a str,
+            &[u8],
+            &Properties<'a>,
+        ) -> T,
     {
         match control_packet {
             ReceivedPacket::ConnAck(ack) => {
@@ -702,20 +713,24 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock>
 /// # Note
 /// To connect and maintain an MQTT connection, the `Minimq::poll()` method must be called
 /// regularly.
-pub struct Minimq<'buf, TcpStack, Clock>
+pub struct Minimq<'buf, TcpStack, Clock, Broker>
 where
     TcpStack: TcpClientStack,
     Clock: embedded_time::Clock,
+    Broker: crate::Broker,
 {
-    client: MqttClient<'buf, TcpStack, Clock>,
+    client: MqttClient<'buf, TcpStack, Clock, Broker>,
     packet_reader: PacketReader<'buf>,
 }
 
-impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock> Minimq<'buf, TcpStack, Clock> {
+impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate::Broker>
+    Minimq<'buf, TcpStack, Clock, Broker>
+{
     /// Construct a new MQTT interface.
     ///
     /// # Args
-    /// * `broker` - The IP address of the broker to connect to.
+    /// * `broker` - The broker to connect to. See [crate::broker::NamedBroker] and
+    /// [crate::broker::IpBroker].
     /// * `client_id` The client ID to use for communicating with the broker. If empty, rely on the
     ///   broker to automatically assign a client ID.
     /// * `network_stack` - The network stack to use for communication.
@@ -725,7 +740,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock> Minimq<'buf, T
     /// A `Minimq` object that can be used for publishing messages, subscribing to topics, and
     /// managing the MQTT state.
     pub fn new(
-        broker: IpAddr,
+        broker: impl Into<Broker>,
         client_id: &str,
         network_stack: TcpStack,
         clock: Clock,
@@ -740,7 +755,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock> Minimq<'buf, T
         let minimq = Minimq {
             client: MqttClient {
                 sm: StateMachine::new(ClientContext::new(clock, session_state)),
-                broker: SocketAddr::new(broker, MQTT_INSECURE_DEFAULT_PORT),
+                broker: broker.into(),
                 will: None,
                 network: InterfaceHolder::new(network_stack, tx_buffer),
                 max_packet_size: rx_buffer.len(),
@@ -773,8 +788,12 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock> Minimq<'buf, T
     /// subscriptions or session state.
     pub fn poll<F, T>(&mut self, mut f: F) -> Result<Option<T>, Error<TcpStack::Error>>
     where
-        for<'a> F:
-            FnMut(&mut MqttClient<'buf, TcpStack, Clock>, &'a str, &[u8], &Properties<'a>) -> T,
+        for<'a> F: FnMut(
+            &mut MqttClient<'buf, TcpStack, Clock, Broker>,
+            &'a str,
+            &[u8],
+            &Properties<'a>,
+        ) -> T,
     {
         self.client.update()?;
 
@@ -822,7 +841,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock> Minimq<'buf, T
     }
 
     /// Directly access the MQTT client.
-    pub fn client(&mut self) -> &mut MqttClient<'buf, TcpStack, Clock> {
+    pub fn client(&mut self) -> &mut MqttClient<'buf, TcpStack, Clock, Broker> {
         &mut self.client
     }
 }

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -15,7 +15,7 @@ fn main() -> std::io::Result<()> {
     let mut session = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::new(
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost,
         "",
         stack,

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -16,7 +16,7 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost,
+        localhost.into(),
         "",
         stack,
         StandardClock::default(),

--- a/tests/exactly_once_subscription.rs
+++ b/tests/exactly_once_subscription.rs
@@ -15,7 +15,7 @@ fn main() -> std::io::Result<()> {
     let mut session = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::new(
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost,
         "",
         stack,

--- a/tests/exactly_once_subscription.rs
+++ b/tests/exactly_once_subscription.rs
@@ -16,7 +16,7 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost,
+        localhost.into(),
         "",
         stack,
         StandardClock::default(),

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -12,7 +12,7 @@ fn main() -> std::io::Result<()> {
     let mut session = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::new(
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost,
         "",
         stack,

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -13,7 +13,7 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost,
+        localhost.into(),
         "",
         stack,
         StandardClock::default(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,7 +12,7 @@ fn main() -> std::io::Result<()> {
     let mut session = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::new(
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost,
         "",
         stack,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost,
+        localhost.into(),
         "",
         stack,
         StandardClock::default(),

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -12,7 +12,7 @@ fn main() -> std::io::Result<()> {
     let mut session = [0u8; 256];
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::new(
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost,
         "",
         stack,

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -13,7 +13,7 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost,
+        localhost.into(),
         "",
         stack,
         StandardClock::default(),

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -19,7 +19,7 @@ fn main() -> std::io::Result<()> {
     let stack = stack::MitmStack::new(&sockets);
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost,
+        localhost.into(),
         "",
         stack,
         StandardClock::default(),

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -18,7 +18,7 @@ fn main() -> std::io::Result<()> {
     let sockets = std::cell::RefCell::new(Vec::new());
     let stack = stack::MitmStack::new(&sockets);
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let mut mqtt = Minimq::new(
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost,
         "",
         stack,


### PR DESCRIPTION
Adds support for using brokers by domain name.

Fixes #120 

TODO:
- [x] Test with a DNS named broker locally
- [x] Document the broker configurations

cc @jordens 