### PR TITLE
Refactoring configuration to builder semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This document describes the changes to Minimq between releases.
 ## Changed
 * [breaking] Const generics for message size and allowable in-flight messages have been removed.
   Instead, the user now supplies an RX buffer, a TX buffer, and a session state buffer.
+ * Setup-only configuration APIs such as `set_will()` and `set_keepalive_interval()` have been moved
+ to a new `Config` structure that is supplied to the `Minimq::new()` constructor to simplify the
+ client.
 
 ## Added
 * Support for subscribing at `QoS::ExactlyOnce`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{ProtocolError, Will};
-use core::str::FromStr;
+use core::convert::TryFrom;
 use embedded_time::duration::{Extensions, Milliseconds};
 use heapless::String;
 
@@ -42,7 +42,8 @@ impl<'a> Config<'a> {
 
     /// Specify a known client ID to use. If not assigned, the broker will auto assign an ID.
     pub fn client_id(mut self, id: &str) -> Result<Self, ProtocolError> {
-        self.client_id = String::from_str(id).or(Err(ProtocolError::ProvidedClientIdTooLong))?;
+        self.client_id =
+            String::try_from(id).map_err(|_| ProtocolError::ProvidedClientIdTooLong)?;
         Ok(self)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{ProtocolError, Will};
 use core::str::FromStr;
-use embedded_time::duration::Milliseconds;
+use embedded_time::duration::{Extensions, Milliseconds};
 use heapless::String;
 
 /// Configuration specifying the operational state of the MQTT client.
@@ -9,7 +9,7 @@ pub struct Config<'a> {
     pub(crate) tx_buffer: &'a mut [u8],
     pub(crate) state_buffer: &'a mut [u8],
     pub(crate) client_id: String<64>,
-    pub(crate) keepalive_interval: Option<Milliseconds<u32>>,
+    pub(crate) keepalive_interval: Milliseconds<u32>,
     pub(crate) downgrade_qos: bool,
     pub(crate) will: Option<Will<'a>>,
 }
@@ -28,7 +28,7 @@ impl<'a> Config<'a> {
             tx_buffer: tx,
             state_buffer: &mut [],
             client_id: String::new(),
-            keepalive_interval: None,
+            keepalive_interval: 59_000.milliseconds(),
             downgrade_qos: false,
             will: None,
         }
@@ -56,8 +56,7 @@ impl<'a> Config<'a> {
     /// * `interval` - The keep-alive interval in seconds. A ping will be transmitted if no other
     /// messages are sent within 50% of the keep-alive interval.
     pub fn keepalive_interval(mut self, seconds: u16) -> Self {
-        self.keepalive_interval
-            .replace(Milliseconds(seconds as u32 * 1000));
+        self.keepalive_interval = Milliseconds(seconds as u32 * 1000);
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,8 @@ use embedded_time::duration::{Extensions, Milliseconds};
 use heapless::String;
 
 /// Configuration specifying the operational state of the MQTT client.
-pub struct Config<'a> {
+pub struct Config<'a, Broker: crate::Broker> {
+    pub(crate) broker: Broker,
     pub(crate) rx_buffer: &'a mut [u8],
     pub(crate) tx_buffer: &'a mut [u8],
     pub(crate) state_buffer: &'a mut [u8],
@@ -14,7 +15,7 @@ pub struct Config<'a> {
     pub(crate) will: Option<Will<'a>>,
 }
 
-impl<'a> Config<'a> {
+impl<'a, Broker: crate::Broker> Config<'a, Broker> {
     /// Construct configuration for the MQTT client.
     ///
     /// # Args
@@ -22,8 +23,9 @@ impl<'a> Config<'a> {
     /// receive packet length.
     /// * `tx` - Memory used for transmitting messages. The length of this buffer is the max
     /// transmit length.
-    pub fn new(rx: &'a mut [u8], tx: &'a mut [u8]) -> Self {
+    pub fn new(broker: Broker, rx: &'a mut [u8], tx: &'a mut [u8]) -> Self {
         Self {
+            broker,
             rx_buffer: rx,
             tx_buffer: tx,
             state_buffer: &mut [],

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,79 @@
+use crate::{ProtocolError, Will};
+use core::str::FromStr;
+use embedded_time::duration::Milliseconds;
+use heapless::String;
+
+/// Configuration specifying the operational state of the MQTT client.
+pub struct Config<'a> {
+    pub(crate) rx_buffer: &'a mut [u8],
+    pub(crate) tx_buffer: &'a mut [u8],
+    pub(crate) state_buffer: &'a mut [u8],
+    pub(crate) client_id: String<64>,
+    pub(crate) keepalive_interval: Option<Milliseconds<u32>>,
+    pub(crate) downgrade_qos: bool,
+    pub(crate) will: Option<Will<'a>>,
+}
+
+impl<'a> Config<'a> {
+    /// Construct configuration for the MQTT client.
+    ///
+    /// # Args
+    /// * `rx` - Memory used for receiving messages. The length of this buffer is the maximum
+    /// receive packet length.
+    /// * `tx` - Memory used for transmitting messages. The length of this buffer is the max
+    /// transmit length.
+    pub fn new(rx: &'a mut [u8], tx: &'a mut [u8]) -> Self {
+        Self {
+            rx_buffer: rx,
+            tx_buffer: tx,
+            state_buffer: &mut [],
+            client_id: String::new(),
+            keepalive_interval: None,
+            downgrade_qos: false,
+            will: None,
+        }
+    }
+
+    /// Provide additional buffer space if messages above [QoS::AtMostOnce] are required.
+    pub fn session_state(mut self, buffer: &'a mut [u8]) -> Self {
+        self.state_buffer = buffer;
+        self
+    }
+
+    /// Specify a known client ID to use. If not assigned, the broker will auto assign an ID.
+    pub fn client_id(mut self, id: &str) -> Result<Self, ProtocolError> {
+        self.client_id = String::from_str(id).or(Err(ProtocolError::ProvidedClientIdTooLong))?;
+        Ok(self)
+    }
+
+    /// Configure the MQTT keep-alive interval.
+    ///
+    /// # Note
+    /// The broker may override the requested keep-alive interval. Any value requested by the
+    /// broker will be used instead.
+    ///
+    /// # Args
+    /// * `interval` - The keep-alive interval in seconds. A ping will be transmitted if no other
+    /// messages are sent within 50% of the keep-alive interval.
+    pub fn keepalive_interval(mut self, seconds: u16) -> Self {
+        self.keepalive_interval
+            .replace(Milliseconds(seconds as u32 * 1000));
+        self
+    }
+
+    /// Specify if publication [QoS] should be automatically downgraded to the maximum supported by
+    /// the server if they exceed the server [QoS] maximum.
+    pub fn autodowngrade_qos(mut self) -> Self {
+        self.downgrade_qos = true;
+        self
+    }
+
+    /// Specify the Will message to be sent if the client disconnects.
+    ///
+    /// # Args
+    /// * `will` - The will to use.
+    pub fn will(mut self, will: Will<'a>) -> Self {
+        self.will.replace(will);
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! Below is a sample snippet showing how this library is used.
 //!
 //! ```no_run
-//! use minimq::{Minimq, Publication};
+//! use minimq::{Config, Minimq, Publication};
 //!
 //! // Construct an MQTT client with a maximum packet size of 256 bytes
 //! // and a maximum of 16 messages that are allowed to be "in flight".
@@ -36,12 +36,12 @@
 //! let localhost: embedded_nal::IpAddr = "127.0.0.1".parse().unwrap();
 //! let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
 //!         localhost.into(),
-//!         "test",
 //!         std_embedded_nal::Stack::default(),
 //!         std_embedded_time::StandardClock::default(),
-//!         &mut rx_buffer,
-//!         &mut tx_buffer,
-//!         &mut session).unwrap();
+//!         Config::new(&mut rx_buffer, &mut tx_buffer)
+//!             .session_state(&mut session)
+//!             .client_id("test").unwrap(),
+//!         );
 //!
 //! let mut subscribed = false;
 //!
@@ -66,11 +66,8 @@
 //! ```
 
 pub mod broker;
+pub mod config;
 mod de;
-mod ser;
-
-pub use broker::Broker;
-
 mod message_types;
 pub mod mqtt_client;
 mod network_manager;
@@ -80,11 +77,14 @@ pub mod publication;
 mod reason_codes;
 mod republication;
 mod ring_buffer;
+mod ser;
 mod session_state;
 pub mod types;
 mod varint;
 mod will;
 
+pub use broker::Broker;
+pub use config::Config;
 pub use properties::Property;
 pub use publication::Publication;
 pub use reason_codes::ReasonCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,9 @@
 //! let mut session = [0; 256];
 //! let localhost: embedded_nal::IpAddr = "127.0.0.1".parse().unwrap();
 //! let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-//!         localhost.into(),
 //!         std_embedded_nal::Stack::default(),
 //!         std_embedded_time::StandardClock::default(),
-//!         Config::new(&mut rx_buffer, &mut tx_buffer)
+//!         Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
 //!             .session_state(&mut session)
 //!             .client_id("test").unwrap(),
 //!         );

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use core::convert::{TryFrom, TryInto};
 use embedded_time::{
-    duration::{Extensions, Milliseconds, Seconds},
+    duration::{Milliseconds, Seconds},
     Instant,
 };
 
@@ -54,7 +54,7 @@ struct ClientContext<'a, Clock: embedded_time::Clock> {
     send_quota: u16,
     max_send_quota: u16,
     maximum_packet_size: Option<u32>,
-    keep_alive_interval: Option<Milliseconds<u32>>,
+    keep_alive_interval: Milliseconds<u32>,
     pending_subscriptions: heapless::Vec<u16, 32>,
 
     ping_timeout: Option<Instant<Clock>>,
@@ -67,7 +67,11 @@ impl<'a, Clock> ClientContext<'a, Clock>
 where
     Clock: embedded_time::Clock,
 {
-    pub fn new(clock: Clock, session_state: SessionState<'a>) -> Self {
+    pub fn new(
+        clock: Clock,
+        session_state: SessionState<'a>,
+        keepalive: Milliseconds<u32>,
+    ) -> Self {
         Self {
             session_state,
             send_quota: u16::MAX,
@@ -77,7 +81,7 @@ where
             ping_timeout: None,
             next_ping: None,
             max_qos: None,
-            keep_alive_interval: Some(59_000.milliseconds()),
+            keep_alive_interval: keepalive,
             maximum_packet_size: None,
         }
     }
@@ -111,9 +115,8 @@ where
         self.ping_timeout = None;
 
         // The next ping should be sent out in half the keep-alive interval from now.
-        if let Some(interval) = self.keep_alive_interval {
-            self.next_ping.replace(self.clock.try_now()? + interval / 2);
-        }
+        self.next_ping
+            .replace(self.clock.try_now()? + self.keep_alive_interval / 2);
 
         Ok(())
     }
@@ -147,20 +150,17 @@ where
 
         let now = self.clock.try_now()?;
 
-        Ok(self
-            .keep_alive_interval
-            .zip(self.next_ping)
-            .map(|(keep_alive_interval, ping_deadline)| {
-                // Update the next ping deadline if the ping is due.
-                if now > ping_deadline {
-                    // The next ping should be sent out in half the keep-alive interval from now.
-                    self.next_ping.replace(now + keep_alive_interval / 2);
-                    self.ping_timeout.replace(now + PING_TIMEOUT);
-                }
+        let Some(ping_deadline) = self.next_ping else {
+            return Ok(false);
+        };
+        // Update the next ping deadline if the ping is due.
+        if now > ping_deadline {
+            // The next ping should be sent out in half the keep-alive interval from now.
+            self.next_ping.replace(now + self.keep_alive_interval / 2);
+            self.ping_timeout.replace(now + PING_TIMEOUT);
+        }
 
-                now > ping_deadline
-            })
-            .unwrap_or(false))
+        Ok(now > ping_deadline)
     }
 
     /// Get the keep-alive interval as an integer number of seconds.
@@ -168,11 +168,7 @@ where
     /// # Note
     /// If no keep-alive interval is specified, zero is returned.
     pub fn keepalive_interval(&self) -> u16 {
-        (self
-            .keep_alive_interval
-            .unwrap_or_else(|| 0.milliseconds())
-            .0
-            / 1000) as u16
+        (self.keep_alive_interval.0 / 1000) as u16
     }
 }
 
@@ -235,8 +231,7 @@ where
                         String::from_str(id.0).or(Err(ProtocolError::ProvidedClientIdTooLong))?;
                 }
                 Property::ServerKeepAlive(keep_alive) => {
-                    self.keep_alive_interval
-                        .replace(Milliseconds(keep_alive as u32 * 1000));
+                    self.keep_alive_interval = Milliseconds(keep_alive as u32 * 1000);
                 }
                 Property::ReceiveMaximum(max) => {
                     self.send_quota = max.max(self.session_state.max_send_quota());
@@ -707,14 +702,13 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
             config.tx_buffer.len(),
         );
 
-        let mut client_context = ClientContext::new(clock, session_state);
-        if let Some(keepalive) = config.keepalive_interval {
-            client_context.keep_alive_interval.replace(keepalive);
-        }
-
         Minimq {
             client: MqttClient {
-                sm: StateMachine::new(client_context),
+                sm: StateMachine::new(ClientContext::new(
+                    clock,
+                    session_state,
+                    config.keepalive_interval,
+                )),
                 downgrade_qos: config.downgrade_qos,
                 broker,
                 will: config.will,

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -690,12 +690,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
     /// # Returns
     /// A `Minimq` object that can be used for publishing messages, subscribing to topics, and
     /// managing the MQTT state.
-    pub fn new(
-        broker: Broker,
-        network_stack: TcpStack,
-        clock: Clock,
-        config: Config<'buf>,
-    ) -> Self {
+    pub fn new(network_stack: TcpStack, clock: Clock, config: Config<'buf, Broker>) -> Self {
         let session_state = SessionState::new(
             config.client_id,
             config.state_buffer,
@@ -710,7 +705,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
                     config.keepalive_interval,
                 )),
                 downgrade_qos: config.downgrade_qos,
-                broker,
+                broker: config.broker,
                 will: config.will,
                 network: InterfaceHolder::new(network_stack, config.tx_buffer),
                 max_packet_size: config.rx_buffer.len(),

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -17,17 +17,12 @@ fn main() -> std::io::Result<()> {
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost.into(),
-        "",
         stack,
         StandardClock::default(),
-        &mut rx_buffer,
-        &mut tx_buffer,
-        &mut session,
-    )
-    .unwrap();
-
-    // Use a keepalive interval for the client.
-    mqtt.client().set_keepalive_interval(60).unwrap();
+        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .keepalive_interval(60),
+    );
 
     let mut published = false;
     let mut subscribed = false;

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -16,10 +16,9 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost.into(),
         stack,
         StandardClock::default(),
-        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
             .session_state(&mut session)
             .keepalive_interval(60),
     );

--- a/tests/exactly_once_subscription.rs
+++ b/tests/exactly_once_subscription.rs
@@ -17,17 +17,12 @@ fn main() -> std::io::Result<()> {
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost.into(),
-        "",
         stack,
         StandardClock::default(),
-        &mut rx_buffer,
-        &mut tx_buffer,
-        &mut session,
-    )
-    .unwrap();
-
-    // Use a keepalive interval for the client.
-    mqtt.client().set_keepalive_interval(60).unwrap();
+        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .keepalive_interval(60),
+    );
 
     let mut published = false;
     let mut subscribed = false;

--- a/tests/exactly_once_subscription.rs
+++ b/tests/exactly_once_subscription.rs
@@ -16,10 +16,9 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost.into(),
         stack,
         StandardClock::default(),
-        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
             .session_state(&mut session)
             .keepalive_interval(60),
     );

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -13,10 +13,9 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost.into(),
         stack,
         StandardClock::default(),
-        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
             .session_state(&mut session)
             .keepalive_interval(60),
     );

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -14,17 +14,12 @@ fn main() -> std::io::Result<()> {
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost.into(),
-        "",
         stack,
         StandardClock::default(),
-        &mut rx_buffer,
-        &mut tx_buffer,
-        &mut session,
-    )
-    .unwrap();
-
-    // Use a keepalive interval for the client.
-    mqtt.client().set_keepalive_interval(60).unwrap();
+        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .keepalive_interval(60),
+    );
 
     let mut published = false;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,6 +7,8 @@ use std_embedded_time::StandardClock;
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
+    let will = Will::new("exit", "Test complete".as_bytes(), &[]).unwrap();
+
     let mut rx_buffer = [0u8; 256];
     let mut tx_buffer = [0u8; 256];
     let mut session = [0u8; 256];
@@ -14,24 +16,17 @@ fn main() -> std::io::Result<()> {
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost.into(),
-        "",
         stack,
         StandardClock::default(),
-        &mut rx_buffer,
-        &mut tx_buffer,
-        &mut session,
-    )
-    .unwrap();
-
-    // Use a keepalive interval for the client.
-    mqtt.client().set_keepalive_interval(60).unwrap();
+        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .will(will)
+            .keepalive_interval(60),
+    );
 
     let mut published = false;
     let mut subscribed = false;
     let mut responses = 0;
-
-    let will = Will::new("exit", "Test complete".as_bytes(), &[]).unwrap();
-    mqtt.client().set_will(will).unwrap();
 
     loop {
         // Continually poll the client until there is no more data.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,10 +15,9 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost.into(),
         stack,
         StandardClock::default(),
-        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
             .session_state(&mut session)
             .will(will)
             .keepalive_interval(60),

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -13,10 +13,9 @@ fn main() -> std::io::Result<()> {
     let stack = std_embedded_nal::Stack::default();
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost.into(),
         stack,
         StandardClock::default(),
-        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
             .session_state(&mut session)
             .keepalive_interval(60),
     );

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -14,17 +14,12 @@ fn main() -> std::io::Result<()> {
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost.into(),
-        "",
         stack,
         StandardClock::default(),
-        &mut rx_buffer,
-        &mut tx_buffer,
-        &mut session,
-    )
-    .unwrap();
-
-    // Use a keepalive interval for the client.
-    mqtt.client().set_keepalive_interval(60).unwrap();
+        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .keepalive_interval(60),
+    );
 
     let mut published = false;
     let mut subscribed = false;

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -19,10 +19,9 @@ fn main() -> std::io::Result<()> {
     let stack = stack::MitmStack::new(&sockets);
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
-        localhost.into(),
         stack,
         StandardClock::default(),
-        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
             .session_state(&mut session)
             .keepalive_interval(1),
     );

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -20,17 +20,12 @@ fn main() -> std::io::Result<()> {
     let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
         localhost.into(),
-        "",
         stack,
         StandardClock::default(),
-        &mut rx_buffer,
-        &mut tx_buffer,
-        &mut session,
-    )
-    .unwrap();
-
-    // Use a keepalive interval for the client.
-    mqtt.client().set_keepalive_interval(1).unwrap();
+        minimq::Config::new(&mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .keepalive_interval(1),
+    );
 
     // 1. Poll until we're connected and subscribed to a test topic
     while !mqtt.client().is_connected() {


### PR DESCRIPTION
This PR refactors the setup of the Minimq client into a single `Config` struct. This removes the need to do run-time checks on the client state and makes it simpler to see which buffers are being used for what. It also cuts down on the number of arguments needed in `Minimq::new()`