### PR TITLE
Refactoring publication to support zero-copy serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document describes the changes to Minimq between releases.
  to a new `Config` structure that is supplied to the `Minimq::new()` constructor to simplify the
  client.
 
+
 ## Added
 * Support for subscribing at `QoS::ExactlyOnce`
 * Support for downgrading the `QoS` to the maximum permitted by the server

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,16 +88,15 @@ impl<'a, Broker: crate::Broker> Config<'a, Broker> {
         will: Will<'_>,
     ) -> Result<Self, crate::ser::Error> {
         self = self.will_buffer(buf);
-        self.will(will)?;
-        Ok(self)
+        self.will(will)
     }
 
     /// Specify the Will message to be sent if the client disconnects.
     ///
     /// # Args
     /// * `will` - The will to use.
-    pub fn will(&mut self, will: Will<'_>) -> Result<&mut Self, crate::ser::Error> {
-        let Some(WillState::BufferAvailable(buf)) = self.will.take() else {
+    pub fn will(mut self, will: Will<'_>) -> Result<Self, crate::ser::Error> {
+        let Some(WillState::BufferAvailable(buf)) = self.will else {
             return Err(crate::ser::Error::InsufficientMemory);
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,15 +88,16 @@ impl<'a, Broker: crate::Broker> Config<'a, Broker> {
         will: Will<'_>,
     ) -> Result<Self, crate::ser::Error> {
         self = self.will_buffer(buf);
-        self.will(will)
+        self.will(will)?;
+        Ok(self)
     }
 
     /// Specify the Will message to be sent if the client disconnects.
     ///
     /// # Args
     /// * `will` - The will to use.
-    pub fn will(mut self, will: Will<'_>) -> Result<Self, crate::ser::Error> {
-        let Some(WillState::BufferAvailable(buf)) = self.will else {
+    pub fn will(&mut self, will: Will<'_>) -> Result<&mut Self, crate::ser::Error> {
+        let Some(WillState::BufferAvailable(buf)) = self.will.take() else {
             return Err(crate::ser::Error::InsufficientMemory);
         };
 

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 #[derive(Debug)]
 pub enum ReceivedPacket<'a> {
     ConnAck(ConnAck<'a>),
-    Publish(Pub<'a, &'a [u8]>),
+    Publish(Pub<'a>),
     PubAck(PubAck<'a>),
     SubAck(SubAck<'a>),
     PubRel(PubRel<'a>),
@@ -83,7 +83,7 @@ impl<'de> serde::de::Visitor<'de> for ControlPacketVisitor {
 
                 let properties = seq.next_element()?.unwrap();
 
-                let publish: Pub<'_, &[u8]> = Pub {
+                let publish = Pub {
                     topic,
                     packet_id,
                     properties,

--- a/src/de/received_packet.rs
+++ b/src/de/received_packet.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 #[derive(Debug)]
 pub enum ReceivedPacket<'a> {
     ConnAck(ConnAck<'a>),
-    Publish(Pub<'a>),
+    Publish(Pub<'a, &'a [u8]>),
     PubAck(PubAck<'a>),
     SubAck(SubAck<'a>),
     PubRel(PubRel<'a>),
@@ -83,7 +83,7 @@ impl<'de> serde::de::Visitor<'de> for ControlPacketVisitor {
 
                 let properties = seq.next_element()?.unwrap();
 
-                let publish = Pub {
+                let publish: Pub<'_, &[u8]> = Pub {
                     topic,
                     packet_id,
                     properties,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ mod will;
 pub use broker::Broker;
 pub use config::Config;
 pub use properties::Property;
-pub use publication::Publication;
+pub use publication::{DeferredPublication, Publication};
 pub use reason_codes::ReasonCode;
 pub use will::Will;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,18 @@ pub enum ProtocolError {
     Deserialization(crate::de::Error),
 }
 
+#[derive(Debug, PartialEq)]
+pub enum PubError<T, E> {
+    Error(Error<T>),
+    Custom(E),
+}
+
+impl<T, E> From<Error<T>> for PubError<T, E> {
+    fn from(e: Error<T>) -> Self {
+        Self::Error(e)
+    }
+}
+
 impl From<crate::ser::Error> for ProtocolError {
     fn from(err: crate::ser::Error) -> Self {
         ProtocolError::Serialization(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,18 @@ pub enum ProtocolError {
 #[derive(Debug, PartialEq)]
 pub enum PubError<T, E> {
     Error(Error<T>),
-    Custom(E),
+    Serialization(E),
+}
+
+impl<T, E> From<crate::ser::PubError<E>> for PubError<T, E> {
+    fn from(e: crate::ser::PubError<E>) -> Self {
+        match e {
+            crate::ser::PubError::Other(e) => crate::PubError::Serialization(e),
+            crate::ser::PubError::Error(e) => crate::PubError::Error(crate::Error::Minimq(
+                crate::MinimqError::Protocol(ProtocolError::from(e)),
+            )),
+        }
+    }
 }
 
 impl<T, E> From<Error<T>> for PubError<T, E> {

--- a/src/message_types.rs
+++ b/src/message_types.rs
@@ -43,9 +43,8 @@ impl<'a> ControlPacket for ConnAck<'a> {
     const MESSAGE_TYPE: MessageType = MessageType::ConnAck;
 }
 
-impl<'a> ControlPacket for Pub<'a> {
-    const MESSAGE_TYPE: MessageType = MessageType::Publish;
-    fn fixed_header_flags(&self) -> u8 {
+impl<'a, P: crate::publication::ToPayload> Pub<'a, P> {
+    pub fn fixed_header_flags(&self) -> u8 {
         *0u8.set_bits(1..=2, self.qos as u8)
             .set_bit(0, self.retain == Retain::Retained)
     }

--- a/src/message_types.rs
+++ b/src/message_types.rs
@@ -1,7 +1,7 @@
 use crate::{
     packets::{
-        ConnAck, Connect, Disconnect, PingReq, PingResp, Pub, PubAck, PubComp, PubRec, PubRel,
-        SubAck, Subscribe,
+        ConnAck, Connect, Disconnect, OutgoingPub, PingReq, PingResp, PubAck, PubComp, PubRec,
+        PubRel, SubAck, Subscribe,
     },
     Retain,
 };
@@ -43,7 +43,7 @@ impl<'a> ControlPacket for ConnAck<'a> {
     const MESSAGE_TYPE: MessageType = MessageType::ConnAck;
 }
 
-impl<'a, P: crate::publication::ToPayload> Pub<'a, P> {
+impl<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> OutgoingPub<'a, E, F> {
     pub fn fixed_header_flags(&self) -> u8 {
         *0u8.set_bits(1..=2, self.qos as u8)
             .set_bit(0, self.retain == Retain::Retained)

--- a/src/message_types.rs
+++ b/src/message_types.rs
@@ -1,7 +1,7 @@
 use crate::{
     packets::{
-        ConnAck, Connect, Disconnect, OutgoingPub, PingReq, PingResp, PubAck, PubComp, PubRec,
-        PubRel, SubAck, Subscribe,
+        ConnAck, Connect, Disconnect, PingReq, PingResp, Pub, PubAck, PubComp, PubRec, PubRel,
+        SubAck, Subscribe,
     },
     Retain,
 };
@@ -43,7 +43,7 @@ impl<'a> ControlPacket for ConnAck<'a> {
     const MESSAGE_TYPE: MessageType = MessageType::ConnAck;
 }
 
-impl<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> OutgoingPub<'a, E, F> {
+impl<'a, P: crate::publication::ToPayload> Pub<'a, P> {
     pub fn fixed_header_flags(&self) -> u8 {
         *0u8.set_bits(1..=2, self.qos as u8)
             .set_bit(0, self.retain == Retain::Retained)

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -1,9 +1,7 @@
 use crate::{
     de::{received_packet::ReceivedPacket, PacketReader},
     network_manager::InterfaceHolder,
-    packets::{
-        ConnAck, Connect, OutgoingPub, PingReq, PubAck, PubComp, PubRec, PubRel, SubAck, Subscribe,
-    },
+    packets::{ConnAck, Connect, PingReq, Pub, PubAck, PubComp, PubRec, PubRel, SubAck, Subscribe},
     reason_codes::ReasonCode,
     session_state::SessionState,
     types::{Properties, TopicFilter, Utf8String},
@@ -382,10 +380,10 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
     /// # Args
     /// * `publish` - The publication to generate. See [Publication] for a builder pattern to
     /// generate a message.
-    pub fn publish<E, F: FnOnce(&mut [u8]) -> Result<usize, E>>(
+    pub fn publish<P: crate::publication::ToPayload>(
         &mut self,
-        mut publish: OutgoingPub<'_, E, F>,
-    ) -> Result<(), crate::PubError<TcpStack::Error, E>> {
+        mut publish: Pub<'_, P>,
+    ) -> Result<(), crate::PubError<TcpStack::Error, P::Error>> {
         // If we are not yet connected to the broker, we can't transmit a message.
         if !self.is_connected() {
             return Ok(());
@@ -411,16 +409,13 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
                 .replace(self.sm.context_mut().session_state.get_packet_identifier());
         }
 
-        let qos = publish.qos;
-        let id = publish.packet_id;
+        let packet = self.network.send_pub(&publish)?;
 
-        let packet = self.network.send_pub(publish)?;
-
-        if let Some(id) = id {
+        if let Some(id) = publish.packet_id {
             let context = self.sm.context_mut();
             context
                 .session_state
-                .handle_publish(qos, id, packet)
+                .handle_publish(publish.qos, id, packet)
                 .map_err(|e| Error::Minimq(e.into()))?;
             context.send_quota = context.send_quota.checked_sub(1).unwrap();
         }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -380,7 +380,10 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
     /// # Args
     /// * `publish` - The publication to generate. See [Publication] for a builder pattern to
     /// generate a message.
-    pub fn publish(&mut self, mut publish: Pub<'_>) -> Result<(), Error<TcpStack::Error>> {
+    pub fn publish<P: crate::publication::ToPayload>(
+        &mut self,
+        mut publish: Pub<'_, P>,
+    ) -> Result<(), Error<TcpStack::Error>> {
         // If we are not yet connected to the broker, we can't transmit a message.
         if !self.is_connected() {
             return Ok(());
@@ -406,7 +409,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
                 .replace(self.sm.context_mut().session_state.get_packet_identifier());
         }
 
-        let packet = self.network.send_packet(&publish)?;
+        let packet = self.network.send_pub(&publish)?;
 
         if let Some(id) = publish.packet_id {
             let context = self.sm.context_mut();

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -421,7 +421,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
             context
                 .session_state
                 .handle_publish(qos, id, packet)
-                .map_err(|e| crate::Error::Minimq(e.into()))?;
+                .map_err(|e| Error::Minimq(e.into()))?;
             context.send_quota = context.send_quota.checked_sub(1).unwrap();
         }
 

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -5,7 +5,7 @@
 //! simple ownership semantics of reading and writing to the network stack. This allows the network
 //! stack to be used to transmit buffers that may be stored internally in other structs without
 //! violating Rust's borrow rules.
-use crate::{message_types::ControlPacket, packets::OutgoingPub};
+use crate::{message_types::ControlPacket, packets::Pub};
 use embedded_nal::{nb, SocketAddr, TcpClientStack, TcpError};
 use serde::Serialize;
 
@@ -146,10 +146,10 @@ where
         Ok(&self.tx_buffer[offset..][..len])
     }
 
-    pub fn send_pub<E, F: FnOnce(&mut [u8]) -> Result<usize, E>>(
+    pub fn send_pub<P: crate::publication::ToPayload>(
         &mut self,
-        pub_packet: OutgoingPub<'_, E, F>,
-    ) -> Result<&[u8], crate::PubError<TcpStack::Error, E>> {
+        pub_packet: &Pub<'_, P>,
+    ) -> Result<&[u8], crate::PubError<TcpStack::Error, P::Error>> {
         // If there's an unfinished write pending, it's invalid to try to write new data. The
         // previous write must first be completed.
         assert!(self.pending_write.is_none());

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -156,14 +156,7 @@ where
 
         crate::info!("Sending: {:?}", pub_packet);
         let (offset, packet) =
-            crate::ser::MqttSerializer::pub_to_buffer_meta(self.tx_buffer, pub_packet).map_err(
-                |e| match e {
-                    crate::ser::PubError::Other(e) => crate::PubError::Custom(e),
-                    crate::ser::PubError::Error(e) => crate::PubError::Error(crate::Error::Minimq(
-                        crate::MinimqError::Protocol(ProtocolError::from(e)),
-                    )),
-                },
-            )?;
+            crate::ser::MqttSerializer::pub_to_buffer_meta(self.tx_buffer, pub_packet)?;
 
         let len = packet.len();
 

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -5,7 +5,7 @@
 //! simple ownership semantics of reading and writing to the network stack. This allows the network
 //! stack to be used to transmit buffers that may be stored internally in other structs without
 //! violating Rust's borrow rules.
-use crate::message_types::ControlPacket;
+use crate::{message_types::ControlPacket, packets::Pub};
 use embedded_nal::{nb, SocketAddr, TcpClientStack, TcpError};
 use serde::Serialize;
 
@@ -140,6 +140,25 @@ where
         crate::info!("Sending: {:?}", packet);
         let (offset, packet) = crate::ser::MqttSerializer::to_buffer_meta(self.tx_buffer, packet)
             .map_err(ProtocolError::from)?;
+        let len = packet.len();
+
+        self.commit_write(offset, len)?;
+        Ok(&self.tx_buffer[offset..][..len])
+    }
+
+    pub fn send_pub<P: crate::publication::ToPayload>(
+        &mut self,
+        pub_packet: &Pub<'_, P>,
+    ) -> Result<&[u8], Error<TcpStack::Error>> {
+        // If there's an unfinished write pending, it's invalid to try to write new data. The
+        // previous write must first be completed.
+        assert!(self.pending_write.is_none());
+
+        crate::info!("Sending: {:?}", pub_packet);
+        let (offset, packet) =
+            crate::ser::MqttSerializer::pub_to_buffer_meta(self.tx_buffer, pub_packet)
+                .map_err(ProtocolError::from)?;
+
         let len = packet.len();
 
         self.commit_write(offset, len)?;

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -74,7 +74,7 @@ pub struct ConnAck<'a> {
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
 #[derive(Serialize)]
-pub struct OutgoingPub<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
+pub struct Pub<'a, P: crate::publication::ToPayload> {
     /// The topic that the message was received on.
     pub topic: Utf8String<'a>,
 
@@ -86,7 +86,7 @@ pub struct OutgoingPub<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
 
     /// The message to be transmitted.
     #[serde(skip)]
-    pub payload: crate::publication::Payload<'a, E, F>,
+    pub payload: P,
 
     /// Specifies whether or not the message should be retained on the broker.
     #[serde(skip)]
@@ -101,52 +101,18 @@ pub struct OutgoingPub<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
     pub dup: bool,
 }
 
-impl<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> core::fmt::Debug for OutgoingPub<'a, E, F> {
+impl<'a, P: crate::publication::ToPayload> core::fmt::Debug for Pub<'a, P> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut debug = f.debug_struct("Pub");
-        debug
+        f.debug_struct("Pub")
             .field("topic", &self.topic)
             .field("packet_id", &self.packet_id)
             .field("properties", &self.properties)
             .field("retain", &self.retain)
             .field("qos", &self.qos)
-            .field("dup", &self.dup);
-
-        match self.payload {
-            crate::publication::Payload::Borrowed(slice) => {
-                debug.field("payload", &slice);
-            }
-            crate::publication::Payload::Callback(_) => {
-                debug.field("payload", &"<deferred>");
-            }
-        }
-
-        debug.finish()
+            .field("dup", &self.dup)
+            .field("payload", &"<deferred>")
+            .finish()
     }
-}
-
-#[derive(Debug)]
-pub struct Pub<'a> {
-    /// The topic that the message was received on.
-    pub topic: Utf8String<'a>,
-
-    /// The ID of the internal message.
-    pub packet_id: Option<u16>,
-
-    /// The properties transmitted with the publish data.
-    pub properties: Properties<'a>,
-
-    /// The message to be transmitted.
-    pub payload: &'a [u8],
-
-    /// Specifies whether or not the message should be retained on the broker.
-    pub retain: Retain,
-
-    /// Specifies the quality-of-service of the transmission.
-    pub qos: QoS,
-
-    /// Specified true if this message is a duplicate (e.g. it has already been transmitted).
-    pub dup: bool,
 }
 
 /// An MQTT SUBSCRIBE control packet

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -75,7 +75,7 @@ pub struct ConnAck<'a> {
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
 #[derive(Debug, Serialize)]
-pub struct Pub<'a> {
+pub struct Pub<'a, P: crate::publication::ToPayload> {
     /// The topic that the message was received on.
     pub topic: Utf8String<'a>,
 
@@ -86,7 +86,8 @@ pub struct Pub<'a> {
     pub properties: Properties<'a>,
 
     /// The message to be transmitted.
-    pub payload: &'a [u8],
+    #[serde(skip)]
+    pub payload: P,
 
     /// Specifies whether or not the message should be retained on the broker.
     #[serde(skip)]
@@ -256,7 +257,7 @@ mod tests {
         };
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::to_buffer(&mut buffer, &publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &publish).unwrap();
 
         assert_eq!(message, good_publish);
     }
@@ -283,7 +284,7 @@ mod tests {
         };
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::to_buffer(&mut buffer, &publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &publish).unwrap();
 
         assert_eq!(message, good_publish);
     }
@@ -335,7 +336,7 @@ mod tests {
         };
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::to_buffer(&mut buffer, &publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &publish).unwrap();
 
         assert_eq!(message, good_publish);
     }
@@ -367,7 +368,7 @@ mod tests {
         };
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::to_buffer(&mut buffer, &publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &publish).unwrap();
 
         assert_eq!(message, good_publish);
     }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -73,7 +73,7 @@ pub struct ConnAck<'a> {
 }
 
 /// An MQTT PUBLISH packet, containing data to be sent or received.
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub struct Pub<'a, P: crate::publication::ToPayload> {
     /// The topic that the message was received on.
     pub topic: Utf8String<'a>,
@@ -99,6 +99,20 @@ pub struct Pub<'a, P: crate::publication::ToPayload> {
     /// Specified true if this message is a duplicate (e.g. it has already been transmitted).
     #[serde(skip)]
     pub dup: bool,
+}
+
+impl<'a, P: crate::publication::ToPayload> core::fmt::Debug for Pub<'a, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Pub")
+            .field("topic", &self.topic)
+            .field("packet_id", &self.packet_id)
+            .field("properties", &self.properties)
+            .field("retain", &self.retain)
+            .field("qos", &self.qos)
+            .field("dup", &self.dup)
+            .field("payload", &"<deferred>")
+            .finish()
+    }
 }
 
 /// An MQTT SUBSCRIBE control packet

--- a/src/publication.rs
+++ b/src/publication.rs
@@ -10,19 +10,6 @@ pub enum Payload<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
     Callback(F),
 }
 
-impl<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> Payload<'a, E, F> {
-    pub fn serialize(self, buffer: &mut [u8]) -> Result<usize, E> {
-        match self {
-            Payload::Borrowed(slice) => {
-                // TODO: Handle buffer too small?
-                buffer[..slice.len()].copy_from_slice(slice);
-                Ok(slice.len())
-            }
-            Payload::Callback(func) => func(buffer),
-        }
-    }
-}
-
 /// Builder pattern for generating MQTT publications.
 ///
 /// # Note

--- a/src/publication.rs
+++ b/src/publication.rs
@@ -1,13 +1,57 @@
 use crate::{
-    packets::OutgoingPub,
+    packets::Pub,
     properties::Property,
     types::{Properties, Utf8String},
     ProtocolError, QoS, Retain,
 };
 
-pub enum Payload<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
-    Borrowed(&'a [u8]),
-    Callback(F),
+pub trait ToPayload {
+    type Error;
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
+impl<'a> ToPayload for &'a [u8] {
+    type Error = ();
+
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, Self::Error> {
+        if buffer.len() < self.len() {
+            return Err(());
+        }
+        buffer[..self.len()].copy_from_slice(self);
+        Ok(self.len())
+    }
+}
+
+impl<const N: usize> ToPayload for [u8; N] {
+    type Error = ();
+
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, ()> {
+        (&self[..]).serialize(buffer)
+    }
+}
+impl<const N: usize> ToPayload for &[u8; N] {
+    type Error = ();
+
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, ()> {
+        (&self[..]).serialize(buffer)
+    }
+}
+
+pub struct DeferredPayload<E, F: Fn(&mut [u8]) -> Result<usize, E>> {
+    func: F,
+}
+
+impl<E, F: Fn(&mut [u8]) -> Result<usize, E>> DeferredPayload<E, F> {
+    pub fn new(func: F) -> Self {
+        Self { func }
+    }
+}
+
+impl<E, F: Fn(&mut [u8]) -> Result<usize, E>> ToPayload for DeferredPayload<E, F> {
+    type Error = E;
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, E> {
+        (self.func)(buffer)
+    }
 }
 
 /// Builder pattern for generating MQTT publications.
@@ -22,29 +66,19 @@ pub enum Payload<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
 /// It is expected that the user provide a topic either by directly specifying a publication topic
 /// in [Publication::topic], or by parsing a topic from the [Property::ResponseTopic] property
 /// contained within received properties by using the [Publication::reply] API.
-pub struct Publication<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> {
+pub struct Publication<'a, P: ToPayload> {
     topic: Option<&'a str>,
     properties: Properties<'a>,
     qos: QoS,
-    payload: Payload<'a, E, F>,
+    payload: P,
     retain: Retain,
 }
 
-impl<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> Publication<'a, E, F> {
+impl<'a, P: ToPayload> Publication<'a, P> {
     /// Construct a new publication with a payload.
-    pub fn new(payload: &'a [u8]) -> Self {
+    pub fn new(payload: P) -> Self {
         Self {
-            payload: Payload::Borrowed(payload),
-            qos: QoS::AtMostOnce,
-            topic: None,
-            properties: Properties::Slice(&[]),
-            retain: Retain::NotRetained,
-        }
-    }
-
-    pub fn new_deferred(func: F) -> Self {
-        Self {
-            payload: Payload::Callback(func),
+            payload,
             qos: QoS::AtMostOnce,
             topic: None,
             properties: Properties::Slice(&[]),
@@ -136,8 +170,8 @@ impl<'a, E, F: FnOnce(&mut [u8]) -> Result<usize, E>> Publication<'a, E, F> {
     /// # Returns
     /// The message to be published if a publication topic was specified. If no publication topic
     /// was identified, an error is returned.
-    pub fn finish(self) -> Result<OutgoingPub<'a, E, F>, ProtocolError> {
-        Ok(OutgoingPub {
+    pub fn finish(self) -> Result<Pub<'a, P>, ProtocolError> {
+        Ok(Pub {
             topic: Utf8String(self.topic.ok_or(ProtocolError::NoTopic)?),
             properties: self.properties,
             packet_id: None,

--- a/src/publication.rs
+++ b/src/publication.rs
@@ -37,17 +37,17 @@ impl<const N: usize> ToPayload for &[u8; N] {
     }
 }
 
-pub struct DeferredPayload<E, F: Fn(&mut [u8]) -> Result<usize, E>> {
+pub struct DeferredPublication<E, F: Fn(&mut [u8]) -> Result<usize, E>> {
     func: F,
 }
 
-impl<E, F: Fn(&mut [u8]) -> Result<usize, E>> DeferredPayload<E, F> {
-    pub fn new(func: F) -> Self {
-        Self { func }
+impl<E, F: Fn(&mut [u8]) -> Result<usize, E>> DeferredPublication<E, F> {
+    pub fn new<'a>(func: F) -> Publication<'a, Self> {
+        Publication::new(Self { func })
     }
 }
 
-impl<E, F: Fn(&mut [u8]) -> Result<usize, E>> ToPayload for DeferredPayload<E, F> {
+impl<E, F: Fn(&mut [u8]) -> Result<usize, E>> ToPayload for DeferredPublication<E, F> {
     type Error = E;
     fn serialize(&self, buffer: &mut [u8]) -> Result<usize, E> {
         (self.func)(buffer)

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -128,7 +128,10 @@ impl<'a> MqttSerializer<'a> {
             .map_err(PubError::Error)?;
 
         // Next, serialize the payload into the remaining buffer
-        let len = pub_packet.payload.serialize(serializer.remainder()).map_err(PubError::Other)?;
+        let len = pub_packet
+            .payload
+            .serialize(serializer.remainder())
+            .map_err(PubError::Other)?;
         serializer.commit(len).map_err(PubError::Error)?;
 
         // Finally, finish the packet and send it.

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,6 +31,17 @@ pub struct PropertiesIter<'a> {
     index: usize,
 }
 
+impl<'a> PropertiesIter<'a> {
+    pub fn response_topic(&mut self) -> Option<&'a str> {
+        self.find_map(|prop| {
+            if let Ok(crate::Property::ResponseTopic(topic)) = prop {
+                Some(topic.0)
+            } else {
+                None
+            }
+        })
+    }
+}
 impl<'a> core::iter::Iterator for PropertiesIter<'a> {
     type Item = Result<Property<'a>, ProtocolError>;
 

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -63,7 +63,7 @@ impl<'de> serde::de::Visitor<'de> for VarintVisitor {
     fn visit_seq<A: serde::de::SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
         let mut reader = VarintParser {
             seq,
-            _data: core::marker::PhantomData::default(),
+            _data: core::marker::PhantomData,
         };
         Ok(Varint(reader.read_u32_varint()?))
     }

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -63,7 +63,7 @@ impl<'de> serde::de::Visitor<'de> for VarintVisitor {
     fn visit_seq<A: serde::de::SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
         let mut reader = VarintParser {
             seq,
-            _data: core::marker::PhantomData,
+            _data: core::marker::PhantomData::default(),
         };
         Ok(Varint(reader.read_u32_varint()?))
     }

--- a/tests/deferred_payload.rs
+++ b/tests/deferred_payload.rs
@@ -1,0 +1,40 @@
+use minimq::{DeferredPublication, Minimq, QoS};
+
+use embedded_nal::{self, IpAddr, Ipv4Addr};
+use std_embedded_time::StandardClock;
+
+#[test]
+fn main() -> std::io::Result<()> {
+    env_logger::init();
+
+    let mut rx_buffer = [0u8; 256];
+    let mut tx_buffer = [0u8; 256];
+    let mut session = [0u8; 256];
+    let stack = std_embedded_nal::Stack;
+    let localhost = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let mut mqtt: Minimq<'_, _, _, minimq::broker::IpBroker> = Minimq::new(
+        stack,
+        StandardClock::default(),
+        minimq::Config::new(localhost.into(), &mut rx_buffer, &mut tx_buffer)
+            .session_state(&mut session)
+            .keepalive_interval(60),
+    );
+
+    while !mqtt.client().is_connected() {
+        mqtt.poll(|_client, _topic, _payload, _properties| {})
+            .unwrap();
+    }
+
+    assert!(matches!(
+        mqtt.client().publish(
+            DeferredPublication::new(|_buf| { Err("Oops!") })
+                .topic("data")
+                .qos(QoS::ExactlyOnce)
+                .finish()
+                .unwrap(),
+        ),
+        Err(minimq::PubError::Serialization("Oops!"))
+    ));
+
+    Ok(())
+}

--- a/tests/stack/mod.rs
+++ b/tests/stack/mod.rs
@@ -78,7 +78,7 @@ impl TcpSocket {
 
     fn connect(&mut self, remote: embedded_nal::SocketAddr) -> Result<(), Error> {
         let embedded_nal::IpAddr::V4(addr) = remote.ip() else {
-            return Err(Error::new(ErrorKind::Other, "Only IPv4 supported"));
+            return Err(Error::new(ErrorKind::Other, "Only IPv4 supported"))
         };
         let remote = SocketAddr::new(addr.octets().into(), remote.port());
         let soc = TcpStream::connect(remote)?;

--- a/tests/stack/mod.rs
+++ b/tests/stack/mod.rs
@@ -78,7 +78,7 @@ impl TcpSocket {
 
     fn connect(&mut self, remote: embedded_nal::SocketAddr) -> Result<(), Error> {
         let embedded_nal::IpAddr::V4(addr) = remote.ip() else {
-            return Err(Error::new(ErrorKind::Other, "Only IPv4 supported"))
+            return Err(Error::new(ErrorKind::Other, "Only IPv4 supported"));
         };
         let remote = SocketAddr::new(addr.octets().into(), remote.port());
         let soc = TcpStream::connect(remote)?;


### PR DESCRIPTION
This PR is designed to allow an end user to provide a `Publication` message with a yet-to-be-serialized payload. This then allows them to serialize their payload _directly_ into the MQTT TX buffer, which eliminates the need for them serializing and then copying it over into the MQTT payload.

Example:
```rs
client.publish(Publication::new_deferred(|buf| settings.get(key, buf)));
```