### PR TITLE
Updating will to use builder semantics

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,10 @@ impl<'a, Broker: crate::Broker> ConfigBuilder<'a, Broker> {
     ///
     /// # Args
     /// * `will` - The will to use.
-    pub fn will(mut self, will: Will<'_>) -> Result<Self, crate::ProtocolError> {
+    pub fn will(mut self, will: Will<'_>) -> Result<Self, ProtocolError> {
+        if self.will.is_some() {
+            return Err(ProtocolError::WillAlreadySpecified);
+        }
         let will_len = will.serialized_len();
         let (head, tail) = self.buffer.split_at_mut(will_len);
         self.buffer = tail;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ pub enum ProtocolError {
     WrongQos,
     UnsupportedPacket,
     NoTopic,
+    WillAlreadySpecified,
     Failed(ReasonCode),
     Serialization(SerError),
     Deserialization(DeError),

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -442,9 +442,9 @@ mod tests {
 
         let mut buffer: [u8; 900] = [0; 900];
         let mut will_buff = [0; 64];
-        let mut will = crate::will::Will::new("EFG", &[0xAB, 0xCD], &[]).unwrap();
-        will.qos(crate::QoS::AtMostOnce);
-        will.retained(crate::Retain::NotRetained);
+        let will = crate::will::Will::new("EFG", &[0xAB, 0xCD], &[])
+            .unwrap()
+            .qos(crate::QoS::AtMostOnce);
 
         let connect = crate::packets::Connect {
             clean_start: true,

--- a/src/will.rs
+++ b/src/will.rs
@@ -90,7 +90,7 @@ impl<'a> Will<'a> {
     }
 
     /// Specify the will as a retained message.
-    pub fn set_retained(mut self) -> Self {
+    pub fn retained(mut self) -> Self {
         self.retained = Retain::Retained;
         self
     }

--- a/src/will.rs
+++ b/src/will.rs
@@ -89,20 +89,19 @@ impl<'a> Will<'a> {
         topic_len + payload_len + prop_len
     }
 
-    /// Set the retained status of the will.
-    ///
-    /// # Args
-    /// * `retained` - Specifies the retained state of the will.
-    pub fn retained(&mut self, retained: Retain) {
-        self.retained = retained;
+    /// Specify the will as a retained message.
+    pub fn set_retained(mut self) -> Self {
+        self.retained = Retain::Retained;
+        self
     }
 
     /// Set the quality of service at which the will message is sent.
     ///
     /// # Args
     /// * `qos` - The desired quality-of-service level to send the message at.
-    pub fn qos(&mut self, qos: QoS) {
+    pub fn qos(mut self, qos: QoS) -> Self {
         self.qos = qos;
+        self
     }
 }
 


### PR DESCRIPTION
Updating the will to be a bit more usable with builder semantics. Ref https://github.com/quartiq/miniconf/pull/179#discussion_r1311439931

Also flagging an attempt to assign multiple wills as an error. This would potentially just lose allocated memory.