### PR TITLE
Refactoring auth data to not use heapless Strings, fixing build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ pub enum ProtocolError {
     WrongQos,
     UnsupportedPacket,
     NoTopic,
+    AuthAlreadySpecified,
     WillAlreadySpecified,
     Failed(ReasonCode),
     Serialization(SerError),

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -269,7 +269,7 @@ pub struct MqttClient<
     sm: sm::StateMachine<ClientContext<'buf, Clock>>,
     network: InterfaceHolder<'buf, TcpStack>,
     will: Option<SerializedWill<'buf>>,
-    auth: Option<Auth>,
+    auth: Option<Auth<'buf>>,
     downgrade_qos: bool,
     broker: Broker,
     max_packet_size: usize,
@@ -278,25 +278,6 @@ pub struct MqttClient<
 impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate::Broker>
     MqttClient<'buf, TcpStack, Clock, Broker>
 {
-    /// Specify the authentication message used by the server.
-    ///
-    /// # Args
-    /// * `user_name` - The user name
-    /// * `password` - The password
-    #[cfg(feature = "unsecure")]
-    pub fn set_auth(
-        &mut self,
-        user_name: &str,
-        password: &str,
-    ) -> Result<(), Error<TcpStack::Error>> {
-        let auth = Auth { 
-            user_name: String::from_str(user_name).or(Err(Error::ProvidedClientIdTooLong))?, 
-            password: String::from_str(password).or(Err(Error::ProvidedClientIdTooLong))?, 
-        };
-        self.auth = Some(auth);
-        Ok(())
-    }
-
     /// Subscribe to a topic.
     ///
     /// # Note
@@ -463,8 +444,8 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
             keep_alive: self.sm.context().keepalive_interval(),
             properties: Properties::Slice(&properties),
             client_id: Utf8String(self.sm.context().session_state.client_id.as_str()),
-            auth: self.auth.as_ref(),
-            will: self.will.as_ref(),
+            auth: self.auth,
+            will: self.will,
             clean_start: !self.sm.context().session_state.is_present(),
         })?;
 
@@ -734,7 +715,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
                 downgrade_qos: config.downgrade_qos,
                 broker: config.broker,
                 will: config.will,
-                auth: None,
+                auth: config.auth,
                 network: InterfaceHolder::new(network_stack, config.tx_buffer),
                 max_packet_size: config.rx_buffer.len(),
             },

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -45,6 +45,7 @@ impl<'a> serde::Serialize for Connect<'a> {
             flags.set_bit(5, will.retained == Retain::Retained);
         }
 
+        #[cfg(feature = "unsecure")]
         if self.auth.is_some() {
             flags.set_bit(6, true);
             flags.set_bit(7, true);
@@ -61,6 +62,7 @@ impl<'a> serde::Serialize for Connect<'a> {
             item.serialize_field("will", will.contents)?;
         }
 
+        #[cfg(feature = "unsecure")]
         if let Some(auth) = &self.auth {
             item.serialize_field("user_name", &Utf8String(auth.user_name))?;
             item.serialize_field("password", &Utf8String(auth.password))?;

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -23,7 +23,7 @@ pub struct Connect<'a> {
     pub client_id: Utf8String<'a>,
 
     /// An optional authentication message used by the server.
-    pub auth: Option<&'a Auth>,
+    pub auth: Option<Auth<'a>>,
 
     /// An optional will message to be transmitted whenever the connection is lost.
     pub(crate) will: Option<SerializedWill<'a>>,
@@ -49,7 +49,7 @@ impl<'a> serde::Serialize for Connect<'a> {
             flags.set_bit(6, true);
             flags.set_bit(7, true);
         }
-        
+
         let mut item = serializer.serialize_struct("Connect", 0)?;
         item.serialize_field("protocol_name", &Utf8String("MQTT"))?;
         item.serialize_field("protocol_version", &5u8)?;
@@ -59,10 +59,10 @@ impl<'a> serde::Serialize for Connect<'a> {
         item.serialize_field("client_id", &self.client_id)?;
         if let Some(will) = &self.will {
             item.serialize_field("will", will.contents)?;
-        item.serialize_field("will", &self.will)?;
+        }
         if let Some(auth) = &self.auth {
-            item.serialize_field("user_name", &Utf8String(auth.user_name.as_str()))?;
-            item.serialize_field("password", &Utf8String(auth.password.as_str()))?;
+            item.serialize_field("user_name", &Utf8String(auth.user_name))?;
+            item.serialize_field("password", &Utf8String(auth.password))?;
         }
 
         item.end()

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,8 +8,6 @@ use bit_field::BitField;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
-use heapless::String;
-
 #[derive(Debug, PartialEq)]
 pub enum Properties<'a> {
     /// Properties ready for transmission are provided as a list of properties that will be later
@@ -192,10 +190,10 @@ impl<'de> serde::de::Deserialize<'de> for BinaryData<'de> {
     }
 }
 
-#[derive(Debug)]
-pub struct Auth {
-    pub user_name: String<64>,
-    pub password: String<64>,
+#[derive(Debug, Copy, Clone)]
+pub struct Auth<'a> {
+    pub user_name: &'a str,
+    pub password: &'a str,
 }
 
 /// A wrapper type for "UTF-8 Encoded Strings" as defined in the MQTT v5 specification.


### PR DESCRIPTION
This PR updates auth to:
1. Use the `ConfigBuilder` struct for specification to align with other start-up behaviors
2. Uses the `buffer` from the config to back the memory needed to cache the auth credentials, eliminating the need for heapless::String types (which impose run-time cost on users that don't need auth)
3. Excludes auth serialization without the expected feature flag to prevent accidentally providing insecure credentials.

CC @cnmozzie 