### PR TITLE
rj/std embedded nal 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 
 [dependencies]
 bit_field = "0.10.0"
-num_enum = { version = "0.5", default-features = false }
+num_enum = { version = "0.7", default-features = false }
 heapless = { version = "0.7", features = ["serde"] }
 log = {version = "0.4", optional = true}
 embedded-time = "0.12"
@@ -32,6 +32,6 @@ unsecure = []
 
 [dev-dependencies]
 log = "0.4"
-env_logger = "0.7"
+env_logger = "0.10"
 std-embedded-nal = "0.2"
 std-embedded-time = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,5 @@ unsecure = []
 [dev-dependencies]
 log = "0.4"
 env_logger = "0.7"
-std-embedded-nal = "0.1"
+std-embedded-nal = "0.2"
 std-embedded-time = "0.1"
-
-[patch.crates-io.std-embedded-nal]
-git = "https://gitlab.com/ryan-summers/std-embedded-nal"
-branch = "feature/0.7"


### PR DESCRIPTION
- bump std-embedded-nal to v0.2
- bump outdated deps
