### PR TITLE
Handle bad length in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document describes the changes to Minimq between releases.
 
+# [Unreleased]
+
+## Fixed
+* Fixed an issue where a corrupted mqtt header length could result in a crash
+
 # [0.8.0] - 2023-11-01
 
 ## Changed


### PR DESCRIPTION
Prevents a panic in `fn receive_buffer` if a packet with a too big length is received.