### PR TITLE
Removing results from Publication API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document describes the changes to Minimq between releases.
 
+# Unreleased
+
+## Changed
+* The `Publication::finish()` API was removed in favor of a new `Publication::respond()` API for
+constructing replies to previously received messages.
+
 # [0.9.0] - 2024-04-29
 
 ## Fixed
@@ -146,7 +152,7 @@ keep-alive interval
 
 * Initial library release and publish to crates.io
 
-[0.8.0]: https://github.com/quartiq/minimq/releases/tag/0.9.0
+[0.9.0]: https://github.com/quartiq/minimq/releases/tag/0.9.0
 [0.8.0]: https://github.com/quartiq/minimq/releases/tag/0.8.0
 [0.7.0]: https://github.com/quartiq/minimq/releases/tag/0.7.0
 [0.6.2]: https://github.com/quartiq/minimq/releases/tag/0.6.2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,7 @@
 //!         match topic {
 //!             "topic" => {
 //!                println!("{:?}", message);
-//!                let response = Publication::new(message).topic("echo").finish().unwrap();
-//!                client.publish(response).unwrap();
+//!                client.publish(Publication::new("echo", message)).unwrap();
 //!             },
 //!             topic => println!("Unknown topic: {}", topic),
 //!         };

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1,4 +1,5 @@
 use crate::{
+    publication::Publication,
     reason_codes::ReasonCode,
     types::{Auth, Properties, TopicFilter, Utf8String},
     will::SerializedWill,
@@ -126,6 +127,20 @@ impl<'a, P> core::fmt::Debug for Pub<'a, P> {
             .field("dup", &self.dup)
             .field("payload", &"<deferred>")
             .finish()
+    }
+}
+
+impl<'a, P> From<Publication<'a, P>> for Pub<'a, P> {
+    fn from(publication: Publication<'a, P>) -> Self {
+        Self {
+            topic: Utf8String(publication.topic),
+            properties: publication.properties,
+            packet_id: None,
+            payload: publication.payload,
+            retain: publication.retain,
+            qos: publication.qos,
+            dup: false,
+        }
     }
 }
 

--- a/tests/at_least_once_subscription.rs
+++ b/tests/at_least_once_subscription.rs
@@ -49,13 +49,7 @@ fn main() -> std::io::Result<()> {
 
         if !published && mqtt.client().can_publish(QoS::AtLeastOnce) {
             mqtt.client()
-                .publish(
-                    Publication::new("Ping")
-                        .topic("data")
-                        .qos(QoS::AtLeastOnce)
-                        .finish()
-                        .unwrap(),
-                )
+                .publish(Publication::new("data", "Ping").qos(QoS::AtLeastOnce))
                 .unwrap();
             log::info!("Publishing message");
             published = true;

--- a/tests/deferred_payload.rs
+++ b/tests/deferred_payload.rs
@@ -23,11 +23,7 @@ fn main() -> std::io::Result<()> {
 
     assert!(matches!(
         mqtt.client().publish(
-            DeferredPublication::new(|_buf| { Err("Oops!") })
-                .topic("data")
-                .qos(QoS::ExactlyOnce)
-                .finish()
-                .unwrap(),
+            DeferredPublication::new("data", |_buf| { Err("Oops!") }).qos(QoS::ExactlyOnce)
         ),
         Err(minimq::PubError::Serialization("Oops!"))
     ));

--- a/tests/exactly_once_subscription.rs
+++ b/tests/exactly_once_subscription.rs
@@ -50,13 +50,7 @@ fn main() -> std::io::Result<()> {
 
         if !published && mqtt.client().can_publish(QoS::ExactlyOnce) {
             mqtt.client()
-                .publish(
-                    Publication::new("Ping")
-                        .topic("data")
-                        .qos(QoS::ExactlyOnce)
-                        .finish()
-                        .unwrap(),
-                )
+                .publish(Publication::new("data", b"Ping").qos(QoS::ExactlyOnce))
                 .unwrap();
             log::info!("Publishing message");
             published = true;

--- a/tests/exactly_once_transmission.rs
+++ b/tests/exactly_once_transmission.rs
@@ -29,13 +29,7 @@ fn main() -> std::io::Result<()> {
         if mqtt.client().is_connected() && !published && mqtt.client().can_publish(QoS::ExactlyOnce)
         {
             mqtt.client()
-                .publish(
-                    Publication::new("Ping".as_bytes())
-                        .topic("data")
-                        .qos(QoS::ExactlyOnce)
-                        .finish()
-                        .unwrap(),
-                )
+                .publish(Publication::new("data", b"Ping").qos(QoS::ExactlyOnce))
                 .unwrap();
             log::info!("Publishing message");
             published = true;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31,10 +31,7 @@ fn main() -> std::io::Result<()> {
             .poll(|client, topic, payload, properties| {
                 log::info!("{} < {}", topic, core::str::from_utf8(payload).unwrap());
 
-                if let Ok(response) = Publication::new("Pong".as_bytes())
-                    .reply(properties)
-                    .finish()
-                {
+                if let Ok(response) = Publication::respond(properties, b"Pong") {
                     client.publish(response).unwrap();
                 }
 
@@ -63,20 +60,14 @@ fn main() -> std::io::Result<()> {
         } else if !client.subscriptions_pending() && !published {
             println!("PUBLISH request");
             let properties = [Property::ResponseTopic(Utf8String("response"))];
-            let publication = Publication::new(b"Ping")
-                .topic("request")
-                .properties(&properties)
-                .finish()
-                .unwrap();
+            let publication = Publication::new("request", b"Ping").properties(&properties);
 
             client.publish(publication).unwrap();
 
-            let publication = Publication::new(b"Ping")
-                .topic("request")
+            let publication = Publication::new("request", b"Ping")
                 .properties(&properties)
-                .qos(QoS::AtLeastOnce)
-                .finish()
-                .unwrap();
+                .qos(QoS::AtLeastOnce);
+
             client.publish(publication).unwrap();
 
             // The message cannot be ack'd until the next poll call

--- a/tests/poll_result.rs
+++ b/tests/poll_result.rs
@@ -45,13 +45,7 @@ fn main() -> std::io::Result<()> {
             && mqtt.client().can_publish(QoS::ExactlyOnce)
         {
             mqtt.client()
-                .publish(
-                    Publication::new("Ping".as_bytes())
-                        .topic("data")
-                        .qos(QoS::ExactlyOnce)
-                        .finish()
-                        .unwrap(),
-                )
+                .publish(Publication::new("data", b"Ping").qos(QoS::ExactlyOnce))
                 .unwrap();
             log::info!("Publishing message");
             published = true;

--- a/tests/reconnection.rs
+++ b/tests/reconnection.rs
@@ -40,13 +40,7 @@ fn main() -> std::io::Result<()> {
 
     // 2. Send a QoS::AtLeastOnce message
     mqtt.client()
-        .publish(
-            Publication::new("Ping".as_bytes())
-                .topic("test")
-                .qos(QoS::ExactlyOnce)
-                .finish()
-                .unwrap(),
-        )
+        .publish(Publication::new("test", b"Ping").qos(QoS::ExactlyOnce))
         .unwrap();
 
     // Force a disconnect from the broker.


### PR DESCRIPTION
Fixes #159 by refactoring the `Publication` API to avoid forcing an `unwrap()` on all users, and instead moves the `unwrap()` to a new `Publication::respond` API for constructing a new publication.

Users that have a predefined topic no longer need to unnecessarily unwrap or call `finish()` at all.