### PR TITLE
[v0.10] fix: CloseWait with buffered data potentially causing a dead-lock

### DIFF
--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -489,6 +489,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
 
     fn update(&mut self) -> Result<(), Error<TcpStack::Error>> {
         if self.network.socket_was_closed() {
+            self.network.reset();
             info!("Handling closed socket");
             self.sm.process_event(Events::TcpDisconnect).unwrap();
             self.network.allocate_socket()?;
@@ -780,6 +781,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
                 if received > 0 {
                     debug!("Received {} bytes", received);
                 } else {
+                    self.client.update()?;
                     return Ok(None);
                 }
             }
@@ -787,6 +789,7 @@ impl<'buf, TcpStack: TcpClientStack, Clock: embedded_time::Clock, Broker: crate:
             let packet = self.packet_reader.received_packet()?;
             info!("Received {:?}", packet);
             if let Some(result) = self.client.handle_packet(packet, &mut f)? {
+                self.client.update()?;
                 return Ok(Some(result));
             }
         }

--- a/src/network_manager.rs
+++ b/src/network_manager.rs
@@ -36,13 +36,13 @@ where
         }
     }
 
-    pub fn socket_was_closed(&mut self) -> bool {
-        let was_closed = self.connection_died;
-        if was_closed {
-            self.pending_write.take();
-        }
+    pub fn socket_was_closed(&self) -> bool {
+        self.connection_died
+    }
+
+    pub fn reset(&mut self) {
+        self.pending_write.take();
         self.connection_died = false;
-        was_closed
     }
 
     /// Determine if there is a pending packet write that needs to be completed.


### PR DESCRIPTION
When broker sends FIN and socket enters CLOSE_WAIT, tcp socket return `PipeClosed` to the minimq and `connection_died` is set to `true`. But what happens next? If `minimq` is used as `sync` library, `poll` will be called next and `client.update()` will notice that connection died and issue `TcpDisconnected` event, triggering reconnect to the broker. But  with `async` code, every `poll` is weighted and has a reason. `smoltcp` will not issue any `wake` anymore because the socket is in `CLOSE_WAIT` state (nothing can arrive to it), thus until the application tries to write something to mqtt, `minimq` will *not* get polled, reconnect to the broker will not happen.

Thus, the change is simple - before exiting from `poll`, call `update` once more in case connection broke and initiate reconnect. `smoltcp` or other implementation of `embedded_hal::TcpClientStack` will handle the rest.

Alternatives: `async` user can make several `poll` of `minimq` but this is extremely fragile and doesn't scale, not even talking about the waste.

Additionally, I made a simple refactor, as no one will expect `if self.socket_was_closed()` to mutate something. I split it into a getter and a `reset` method.

