### PR TITLE
fix ping strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ heapless = { version = "0.9.1" }
 log = { version = "0.4", default-features = false }
 embedded-io-async = "0.7"
 embedded-nal-async = "0.9"
-embassy-futures = "0.1.2"
 embassy-time = "0.5.1"
 serde = { version = "1", features = ["derive"], default-features = false }
 thiserror = { version = "2", default-features = false }

--- a/src/mqtt_client/core.rs
+++ b/src/mqtt_client/core.rs
@@ -35,7 +35,9 @@ pub(super) struct RuntimeState {
     pub(super) max_send_quota: u16,
     pub(super) maximum_packet_size: Option<u32>,
     pub(super) max_qos: Option<QoS>,
+    /// When to send next PINGREG?
     pub(super) next_ping: Option<Instant>,
+    /// Already send PINGREQ, wait PINGRESP until?
     pub(super) ping_timeout: Option<Instant>,
 }
 
@@ -61,6 +63,11 @@ impl RuntimeState {
             (None, Some(timeout)) => Some(timeout),
             (None, None) => None,
         }
+    }
+
+    pub(super) fn mark_sent(&mut self) {
+        self.next_ping = (self.keepalive_interval.as_secs() != 0)
+            .then_some(Instant::now() + self.keepalive_interval / 2);
     }
 
     pub(super) fn disconnect(&mut self) {
@@ -377,6 +384,7 @@ impl<'buf> Core<'buf> {
             self.handle_disconnect();
             return Err(PubError::Session(Error::Transport(err)));
         }
+        self.runtime.mark_sent();
 
         Ok(())
     }
@@ -421,7 +429,7 @@ impl<'buf> Core<'buf> {
                 return Err(err);
             }
             self.runtime.ping_timeout = Some(now + Duration::from_millis(PING_TIMEOUT_MS));
-            self.runtime.next_ping = Some(now + self.runtime.keepalive_interval / 2);
+            self.runtime.mark_sent();
         }
 
         Ok(())
@@ -617,6 +625,7 @@ impl<'buf> Core<'buf> {
                             return Err(Error::Transport(err));
                         }
                         self.session.outbound.flush_retained(step.packet_id);
+                        self.runtime.mark_sent();
                     }
                     SendState::Sent => {}
                 }
@@ -671,6 +680,7 @@ impl<'buf> Core<'buf> {
                             return Err(Error::Transport(err));
                         }
                         self.session.outbound.flush_release(step.packet_id);
+                        self.runtime.mark_sent();
                     }
                     SendState::Sent => {}
                 }

--- a/src/mqtt_client/protocol.rs
+++ b/src/mqtt_client/protocol.rs
@@ -75,7 +75,7 @@ pub(super) async fn handle_packet<'pkt, 'state, C: Io>(
 
             cx.runtime.state = ConnectionState::Active;
             cx.session.register_connected();
-            cx.runtime.next_ping = Some(now + cx.runtime.keepalive_interval / 2);
+            cx.runtime.mark_sent();
             cx.runtime.ping_timeout = None;
             if ack.session_present {
                 info!("Connected and resumed existing broker session");
@@ -201,6 +201,7 @@ pub(super) async fn handle_packet<'pkt, 'state, C: Io>(
                 cx.runtime.maximum_packet_size,
             )
             .await?;
+            cx.runtime.mark_sent(); // after every write_control_packet
         }
         ReceivedPacket::Publish(info) => {
             let retain = info.retain;
@@ -235,6 +236,7 @@ pub(super) async fn handle_packet<'pkt, 'state, C: Io>(
                         cx.runtime.maximum_packet_size,
                     )
                     .await?;
+                    cx.runtime.mark_sent();
                 }
                 QoS::ExactlyOnce => {
                     let packet_id = info.packet_id.ok_or(ProtocolError::MalformedPacket)?;
@@ -261,6 +263,7 @@ pub(super) async fn handle_packet<'pkt, 'state, C: Io>(
                         cx.runtime.maximum_packet_size,
                     )
                     .await?;
+                    cx.runtime.mark_sent();
                     if duplicate || !reason.success() {
                         debug!(
                             "Ignoring inbound QoS2 PUBLISH after PUBREC packet_id={} duplicate={} reason={:?}",
@@ -270,8 +273,6 @@ pub(super) async fn handle_packet<'pkt, 'state, C: Io>(
                     }
                 }
             }
-
-            cx.runtime.next_ping = Some(now + cx.runtime.keepalive_interval / 2);
             return Ok(Some(InboundPublish::new(
                 info.topic.0,
                 info.payload,

--- a/src/mqtt_client/session.rs
+++ b/src/mqtt_client/session.rs
@@ -1,5 +1,5 @@
-use embassy_futures::select::{Either, select};
-use embassy_time::{Instant, Timer};
+use embassy_time::Instant;
+use embassy_time::{TimeoutError, WithTimeout};
 use embedded_io_async::Error as _;
 use embedded_io_async::ErrorKind;
 
@@ -196,16 +196,15 @@ where
             let Some(connection) = self.connection.as_mut() else {
                 return Err(Error::Disconnected);
             };
-            return match select(self.core.read(connection, now), Timer::at(deadline)).await {
-                Either::First(result) => match result {
-                    Ok(result) => Ok(result),
-                    Err(Error::Transport(err)) => match err.kind() {
-                        ErrorKind::TimedOut | ErrorKind::Interrupted => Ok(None),
-                        _ => Err(Error::Transport(err)),
-                    },
-                    Err(err) => Err(err),
+            let read_result = self.core.read(connection, now);
+            return match read_result.with_deadline(deadline).await {
+                Err(TimeoutError) => Ok(None),
+                Ok(Ok(result)) => Ok(result),
+                Ok(Err(Error::Transport(err))) => match err.kind() {
+                    ErrorKind::TimedOut | ErrorKind::Interrupted => Ok(None),
+                    _ => Err(Error::Transport(err)),
                 },
-                Either::Second(_) => Ok(None),
+                Ok(Err(err)) => Err(err),
             };
         }
 


### PR DESCRIPTION
Work in progress.

Currently the ping strategy seems not follow spec.

https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#:~:text=maximum%20time%20interval

> The Keep Alive is a Two Byte Integer which is a time interval measured in seconds. It is the maximum time interval that is permitted to elapse between the point at which the Client finishes transmitting one MQTT Control Packet and the point it starts sending the next. It is the responsibility of the Client to ensure that the interval between MQTT Control Packets being sent does not exceed the Keep Alive value. If Keep Alive is non-zero **and in the absence of sending any other MQTT Control Packets**, the Client MUST send a PINGREQ packet.

TODO: what does other implement do?