### PR TITLE
error and recv

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The main API is [`Session`].
 - [`ConfigBuilder`]: session configuration
 - [`Io`]: transport boundary for an established byte stream
 - [`Session`]: the client you drive
-- [`InboundPublish`]: output of [`Session::poll()`]
+- [`InboundPublish`]: output of [`Session::recv()`]
 
 ## Example
 
@@ -67,7 +67,7 @@ async fn run() {
         }
 
         loop {
-            match session.poll().await {
+            match session.recv().await {
                 Ok(message) => println!("topic={}", message.topic()),
                 Err(Error::Disconnected) => break,
                 Err(err) => panic!("{err}"),
@@ -85,8 +85,8 @@ Ordinary lack of inbound data must keep the read future pending; if the transpor
 `TimedOut` or `Interrupted`, [`Session::poll()`] treats that as transport failure and disconnects
 the session.
 
-For a TLS connectivity example and for caller-side bounded/cooperative driving via external
-timeouts, see `examples/tls_public_broker.rs`.
+For a TLS connectivity example and for caller-side cooperative driving via external timeouts, see
+`examples/tls_public_broker.rs`.
 
 ## Session Model
 
@@ -94,24 +94,35 @@ You provide packet buffers plus an already-established transport, and a loop tha
 passes that transport into [`Session::connect()`] to establish or resume the broker session.
 
 [`Session::connect()`] takes ownership of the provided transport and performs the unbounded MQTT
-`CONNECT` / `CONNACK` handshake. Once connected, [`Session::poll()`] blocks until an inbound
-publish arrives or the session is lost, while still handling keepalive and retransmission
-internally. The session drops the transport again on graceful disconnect, connection failure, or
+`CONNECT` / `CONNACK` handshake. Once connected:
+- [`Session::recv()`] blocks until the next inbound publish arrives or the session is lost.
+- [`Session::poll()`] blocks until any session progress happens and returns `Ok(None)` for
+  internal-only progress such as ACK handling, replay, or keepalive traffic.
+
+The session drops the transport again on graceful disconnect, connection failure, or
 transport/protocol loss.
 
 - [`ConnectEvent::Connected`] means the broker created a fresh session. Re-establish subscriptions
   here.
 - [`ConnectEvent::Reconnected`] means the broker resumed the existing MQTT session. Existing
   subscriptions and in-flight QoS state were kept.
-- [`Session::poll()`] yields one inbound publish.
+- [`Session::recv()`] yields one inbound publish.
 
-If [`Session::poll()`] returns [`Error::Disconnected`], the caller decides when to call
+If [`Session::recv()`] or [`Session::poll()`] returns [`Error::Disconnected`], the caller decides
+when to call
 [`Session::connect()`] with a fresh transport again.
 Other transport/protocol errors already tear down the attached transport locally; callers should
-handle the error and reconnect rather than retrying `poll()` on the same session state.
+handle the error and reconnect rather than retrying `recv()` or `poll()` on the same session
+state.
 
-For bounded or cooperative polling, wrap the cancel-safe blocking [`Session::poll()`] future in an
-external timeout such as [`embassy_time::with_timeout()`] or [`embassy_time::with_deadline()`].
+For cooperative driving:
+- use [`Session::drive()`] for immediate local progress without waiting for future inbound reads or
+  future session deadlines
+- wrap cancel-safe blocking [`Session::poll()`] or [`Session::recv()`] in an external timeout such
+  as [`embassy_time::with_timeout()`] or [`embassy_time::with_deadline()`]
+- if you need real wall-clock limits, enforce them in the transport's `read`, `write`, and
+  `flush` futures; using the same budget as minimq's internal MQTT round-trip timeout keeps
+  keepalive and transport liveness aligned
 
 ## Buffers
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The main API is [`Session`].
 ## Example
 
 ```no_run
-use core::net::SocketAddr;
 # use std::io;
 # struct MyIo;
 # use embedded_io_async::{ErrorType, Read, Write};
@@ -42,6 +41,7 @@ use core::net::SocketAddr;
 #     }
 # }
 # async fn open_io(_addr: SocketAddr) -> Result<MyIo, io::Error> { todo!() }
+use core::net::SocketAddr;
 use minimq::{Buffers, ConfigBuilder, ConnectEvent, Error, Session, types::TopicFilter};
 
 async fn run() {

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -4,15 +4,10 @@
 //! the cancel-safe blocking `Session::poll()` in an external timeout at the call site.
 
 use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
-use minimq::{
-    ConfigBuilder, ConnectEvent, Property, Publication, QoS, Session, SessionError,
-    types::TopicFilter,
-};
+use minimq::{ConfigBuilder, OpStatus, Publication, QoS, Session, types::TopicFilter};
 use std::error::Error as StdError;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use thiserror::Error;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpStream;
 
 const BROKER_HOST: &str = "broker.emqx.io";
@@ -22,68 +17,21 @@ const PASSWORD: &str = "public";
 const TLS_READ_RECORD_BUFFER_LEN: usize = 16_640;
 const TLS_WRITE_RECORD_BUFFER_LEN: usize = 4_096;
 
-fn kind_from_std(err: &std::io::Error) -> ErrorKind {
-    err.kind().into()
-}
-
-#[derive(Debug, Error)]
-enum EmqxTlsError {
-    #[error("tcp connect error: {0:?}")]
-    Tcp(ErrorKind),
-    #[error("tls error: {0:?}")]
-    Tls(embedded_tls::TlsError),
-}
-
-impl embedded_io_async::Error for EmqxTlsError {
-    fn kind(&self) -> ErrorKind {
-        match self {
-            Self::Tcp(kind) => *kind,
-            Self::Tls(err) => embedded_io_async::Error::kind(err),
-        }
-    }
-}
-
-struct EmqxTlsConnection(TlsConnection<'static, FromTokio<TcpStream>, Aes128GcmSha256>);
-
-impl ErrorType for EmqxTlsConnection {
-    type Error = EmqxTlsError;
-}
-
-impl Read for EmqxTlsConnection {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.0.read(buf).await.map_err(EmqxTlsError::Tls)
-    }
-}
-
-impl Write for EmqxTlsConnection {
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.0.write(buf).await.map_err(EmqxTlsError::Tls)
-    }
-
-    async fn flush(&mut self) -> Result<(), Self::Error> {
-        self.0.flush().await.map_err(EmqxTlsError::Tls)
-    }
-}
-
-async fn connect_tls(host: &str, port: u16) -> Result<EmqxTlsConnection, EmqxTlsError> {
-    let stream = TcpStream::connect((host, port))
-        .await
-        .map_err(|err| EmqxTlsError::Tcp(kind_from_std(&err)))?;
-    let read_record_buffer = Box::leak(Box::new([0u8; TLS_READ_RECORD_BUFFER_LEN]));
-    let write_record_buffer = Box::leak(Box::new([0u8; TLS_WRITE_RECORD_BUFFER_LEN]));
+async fn connect_tls(
+    host: &str,
+    port: u16,
+) -> Result<TlsConnection<'static, FromTokio<TcpStream>, Aes128GcmSha256>, Box<dyn StdError>> {
     let config = TlsConfig::new()
         .with_server_name(host)
         .enable_rsa_signatures();
     let mut tls = TlsConnection::new(
-        FromTokio::new(stream),
-        read_record_buffer,
-        write_record_buffer,
+        FromTokio::new(TcpStream::connect((host, port)).await?),
+        Box::leak(Box::new([0u8; TLS_READ_RECORD_BUFFER_LEN])),
+        Box::leak(Box::new([0u8; TLS_WRITE_RECORD_BUFFER_LEN])),
     );
     let mut provider = UnsecureProvider::new::<Aes128GcmSha256>(rand::rngs::OsRng);
-    tls.open(TlsContext::new(&config, &mut provider))
-        .await
-        .map_err(EmqxTlsError::Tls)?;
-    Ok(EmqxTlsConnection(tls))
+    tls.open(TlsContext::new(&config, &mut provider)).await?;
+    Ok(tls)
 }
 
 fn unique_id(label: &str) -> String {
@@ -94,90 +42,55 @@ fn unique_id(label: &str) -> String {
     format!("minimq-{label}-{nanos}")
 }
 
-async fn connect(
-    session: &mut Session<'_, EmqxTlsConnection>,
-    io: EmqxTlsConnection,
-) -> Result<(), SessionError<EmqxTlsConnection>> {
-    match tokio::time::timeout(Duration::from_secs(10), session.connect(io))
-        .await
-        .unwrap()?
-    {
-        ConnectEvent::Connected | ConnectEvent::Reconnected => Ok(()),
-    }
-}
-
-async fn flush(
-    session: &mut Session<'_, EmqxTlsConnection>,
-) -> Result<(), SessionError<EmqxTlsConnection>> {
-    while !session.is_publish_quiescent() {
-        match tokio::time::timeout(Duration::from_millis(10), session.poll()).await {
-            Ok(Ok(_)) => {}
-            Ok(Err(err)) => return Err(err),
-            Err(_) => {}
-        }
-    }
-    Ok(())
-}
-
-async fn recv(
-    session: &mut Session<'_, EmqxTlsConnection>,
-    topic: &str,
-    payload: &[u8],
-) -> Result<(), SessionError<EmqxTlsConnection>> {
-    loop {
-        match tokio::time::timeout(Duration::from_secs(10), session.recv())
-            .await
-            .unwrap()?
-        {
-            message if message.topic() == topic && message.payload() == payload => {
-                println!(
-                    "received topic={} payload={}",
-                    message.topic(),
-                    payload.escape_ascii()
-                );
-                return Ok(());
-            }
-            _ => {}
-        }
-    }
-}
-
 async fn run() -> Result<(), Box<dyn StdError>> {
     let topic = format!("minimq/examples/tls/{}", unique_id("topic"));
-    let payload = format!("hello over tls {}", unique_id("msg"));
+    let payload_str = format!("hello over tls {}", unique_id("msg"));
+    let payload = payload_str.as_bytes();
 
     let mut sub_storage = [0u8; 4096];
-    let mut pub_storage = [0u8; 4096];
-
     let mut subscriber = Session::new(
         ConfigBuilder::from_buffer(&mut sub_storage, 1024)?
             .client_id(&unique_id("sub"))?
             .auth(USERNAME, PASSWORD.as_bytes())?,
     );
+    subscriber
+        .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
+        .await?;
+    let sub = subscriber
+        .subscribe(&[TopicFilter::new(&topic)], &[])
+        .await?;
+    while subscriber.status(&sub) == OpStatus::Pending {
+        subscriber.poll().await?;
+    }
+
+    let mut pub_storage = [0u8; 4096];
     let mut publisher = Session::new(
         ConfigBuilder::from_buffer(&mut pub_storage, 1024)?
             .client_id(&unique_id("pub"))?
             .auth(USERNAME, PASSWORD.as_bytes())?,
     );
-
-    connect(
-        &mut subscriber,
-        connect_tls(BROKER_HOST, BROKER_PORT).await?,
-    )
-    .await?;
-    subscriber
-        .subscribe(&[TopicFilter::new(&topic)], &[] as &[Property<'_>])
-        .await?;
-    flush(&mut subscriber).await?;
-
-    connect(&mut publisher, connect_tls(BROKER_HOST, BROKER_PORT).await?).await?;
     publisher
-        .publish(Publication::new(&topic, payload.as_bytes()).qos(QoS::AtLeastOnce))
+        .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
         .await?;
-    flush(&mut publisher).await?;
+    let pub_ = publisher
+        .publish(Publication::new(&topic, payload).qos(QoS::AtLeastOnce))
+        .await?
+        .unwrap();
+    while publisher.status(&pub_) == OpStatus::Pending {
+        publisher.poll().await?;
+    }
 
-    recv(&mut subscriber, &topic, payload.as_bytes()).await?;
-    Ok(())
+    loop {
+        let message = subscriber.recv().await?;
+        if message.topic() == topic && message.payload() == payload {
+            println!(
+                "received topic={} payload={}",
+                message.topic(),
+                payload.escape_ascii()
+            );
+            return Ok(());
+        }
+    }
 }
 
 #[tokio::main]

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -7,7 +7,8 @@ use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
 use minimq::{
-    ConfigBuilder, ConnectEvent, Property, Publication, QoS, Session, types::TopicFilter,
+    ConfigBuilder, ConnectEvent, Property, Publication, QoS, Session, SessionError,
+    types::TopicFilter,
 };
 use std::error::Error as StdError;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -96,7 +97,7 @@ fn unique_id(label: &str) -> String {
 async fn connect(
     session: &mut Session<'_, EmqxTlsConnection>,
     io: EmqxTlsConnection,
-) -> Result<(), minimq::SessionError<EmqxTlsConnection>> {
+) -> Result<(), SessionError<EmqxTlsConnection>> {
     match tokio::time::timeout(Duration::from_secs(10), session.connect(io))
         .await
         .unwrap()?
@@ -107,7 +108,7 @@ async fn connect(
 
 async fn flush(
     session: &mut Session<'_, EmqxTlsConnection>,
-) -> Result<(), minimq::SessionError<EmqxTlsConnection>> {
+) -> Result<(), SessionError<EmqxTlsConnection>> {
     while !session.is_publish_quiescent() {
         match tokio::time::timeout(Duration::from_millis(10), session.poll()).await {
             Ok(Ok(_)) => {}
@@ -122,7 +123,7 @@ async fn recv(
     session: &mut Session<'_, EmqxTlsConnection>,
     topic: &str,
     payload: &[u8],
-) -> Result<(), minimq::SessionError<EmqxTlsConnection>> {
+) -> Result<(), SessionError<EmqxTlsConnection>> {
     loop {
         match tokio::time::timeout(Duration::from_secs(10), session.recv())
             .await

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -124,7 +124,7 @@ async fn recv(
     payload: &[u8],
 ) -> Result<(), minimq::SessionError<EmqxTlsConnection>> {
     loop {
-        match tokio::time::timeout(Duration::from_secs(10), session.poll())
+        match tokio::time::timeout(Duration::from_secs(10), session.recv())
             .await
             .unwrap()?
         {

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -47,11 +47,9 @@ async fn run() -> Result<(), Box<dyn StdError>> {
     let payload_str = format!("hello over tls {}", unique_id("msg"));
     let payload = payload_str.as_bytes();
 
-    let mut sub_storage = [0u8; 4096];
+    let mut sub_storage = [0u8; 2048];
     let mut subscriber = Session::new(
-        ConfigBuilder::from_buffer(&mut sub_storage, 1024)?
-            .client_id(&unique_id("sub"))?
-            .auth(USERNAME, PASSWORD.as_bytes())?,
+        ConfigBuilder::from_buffer(&mut sub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
     );
     subscriber
         .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
@@ -63,11 +61,9 @@ async fn run() -> Result<(), Box<dyn StdError>> {
         subscriber.poll().await?;
     }
 
-    let mut pub_storage = [0u8; 4096];
+    let mut pub_storage = [0u8; 2048];
     let mut publisher = Session::new(
-        ConfigBuilder::from_buffer(&mut pub_storage, 1024)?
-            .client_id(&unique_id("pub"))?
-            .auth(USERNAME, PASSWORD.as_bytes())?,
+        ConfigBuilder::from_buffer(&mut pub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
     );
     publisher
         .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,8 +126,9 @@ impl<'a> ConfigBuilder<'a> {
     ///
     /// The ID must fit in the internal fixed-capacity storage.
     pub fn client_id(mut self, id: &str) -> Result<Self, ProtocolError> {
-        self.client_id =
-            String::try_from(id).map_err(|_| ProtocolError::ProvidedClientIdTooLong)?;
+        self.client_id = id
+            .try_into()
+            .map_err(|_| ProtocolError::ProvidedClientIdTooLong)?;
         Ok(self)
     }
 
@@ -238,7 +239,7 @@ mod tests {
     fn will_does_not_consume_tx_buffer() {
         let mut rx = [0; 10];
         let mut tx = [0; 20];
-        let will = Will::new("topic", b"x", &[]).unwrap();
+        let will = Will::new("topic".try_into().unwrap(), b"x", &[]).unwrap();
         let (buffers, _, _, _, _, _, _) = ConfigBuilder::new(Buffers {
             rx: &mut rx,
             tx: &mut tx,

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,17 +82,18 @@ pub struct ConfigBuilder<'a> {
 impl<'a> ConfigBuilder<'a> {
     /// Construct a session configuration from explicit packet buffers.
     ///
-    /// The default session expiry is `u32::MAX`, which requests a long-lived persistent session.
-    /// Call [`session_expiry_interval`](Self::session_expiry_interval) to choose a shorter-lived
-    /// session or `0` for a clean session that expires on disconnect.
+    /// The default session expiry is `0`, which requests a clean session that expires on
+    /// disconnect.
+    /// Call [`session_expiry_interval`](Self::session_expiry_interval) to choose a long-lived
+    /// session.
     pub fn new(buffers: Buffers<'a>) -> Self {
         Self {
             buffers,
             will: None,
             client_id: String::new(),
             auth: None,
-            keepalive_interval: Duration::from_secs(59),
-            session_expiry_interval: u32::MAX,
+            keepalive_interval: Duration::from_secs(60),
+            session_expiry_interval: 0,
             downgrade_qos: false,
         }
     }
@@ -132,7 +133,7 @@ impl<'a> ConfigBuilder<'a> {
 
     /// Set the MQTT v5 session expiry interval, in seconds.
     ///
-    /// The default is `u32::MAX`, which requests a long-lived persistent session.
+    /// The default is `0`, which requests a clean session that expires on disconnect.
     pub fn session_expiry_interval(mut self, seconds: u32) -> Self {
         self.session_expiry_interval = seconds;
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,7 +133,7 @@ impl<'a> ConfigBuilder<'a> {
 
     /// Set the keepalive interval advertised in `CONNECT`.
     ///
-    /// `poll()` must still be driven often enough for the session to honor it.
+    /// `poll()` or `recv()` must still be driven often enough for the session to honor it.
     pub fn keepalive_interval(mut self, seconds: u16) -> Self {
         self.keepalive_interval = Duration::from_secs(seconds as u64);
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{ProtocolError, Will, types::Auth};
+use crate::{ConfigError, Will, types::Auth};
 use embassy_time::Duration;
 use heapless::String;
 
@@ -55,22 +55,14 @@ impl<'a> Buffers<'a> {
     /// assert_eq!(buffers.rx().len(), 4);
     /// assert_eq!(buffers.tx().len(), 12);
     /// ```
-    pub fn split(buffer: &'a mut [u8], rx_size: usize) -> Result<Self, SetupError> {
+    pub fn split(buffer: &'a mut [u8], rx_size: usize) -> Result<Self, ConfigError> {
         if rx_size > buffer.len() {
-            return Err(SetupError::BufferSplit);
+            return Err(ConfigError::BufferSplit);
         }
 
         let (rx, tx) = buffer.split_at_mut(rx_size);
         Ok(Self::new(rx, tx))
     }
-}
-
-/// Setup errors detected before a session is created.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum SetupError {
-    /// The requested RX split does not fit in the provided backing buffer.
-    #[error("buffer split exceeds backing storage")]
-    BufferSplit,
 }
 
 /// Builder for session setup.
@@ -106,16 +98,16 @@ impl<'a> ConfigBuilder<'a> {
     }
 
     /// Construct a session configuration by splitting one backing buffer into RX and TX regions.
-    pub fn from_buffer(buffer: &'a mut [u8], rx_size: usize) -> Result<Self, SetupError> {
+    pub fn from_buffer(buffer: &'a mut [u8], rx_size: usize) -> Result<Self, ConfigError> {
         Ok(Self::new(Buffers::split(buffer, rx_size)?))
     }
 
     /// Attach MQTT username/password authentication.
     ///
-    /// Calling this more than once returns [`ProtocolError::AuthAlreadySpecified`].
-    pub fn auth(mut self, user_name: &'a str, password: &'a [u8]) -> Result<Self, ProtocolError> {
+    /// Calling this more than once returns [`ConfigError::DuplicateConfig`].
+    pub fn auth(mut self, user_name: &'a str, password: &'a [u8]) -> Result<Self, ConfigError> {
         if self.auth.is_some() {
-            return Err(ProtocolError::AuthAlreadySpecified);
+            return Err(ConfigError::DuplicateConfig);
         }
 
         self.auth.replace(Auth::new(user_name, password));
@@ -125,10 +117,8 @@ impl<'a> ConfigBuilder<'a> {
     /// Set the MQTT client identifier.
     ///
     /// The ID must fit in the internal fixed-capacity storage.
-    pub fn client_id(mut self, id: &str) -> Result<Self, ProtocolError> {
-        self.client_id = id
-            .try_into()
-            .map_err(|_| ProtocolError::ProvidedClientIdTooLong)?;
+    pub fn client_id(mut self, id: &str) -> Result<Self, ConfigError> {
+        self.client_id = id.try_into().map_err(|_| ConfigError::ClientIdTooLong)?;
         Ok(self)
     }
 
@@ -167,9 +157,9 @@ impl<'a> ConfigBuilder<'a> {
     }
 
     /// Attach an MQTT will message.
-    pub fn will(mut self, will: Will<'a>) -> Result<Self, ProtocolError> {
+    pub fn will(mut self, will: Will<'a>) -> Result<Self, ConfigError> {
         if self.will.is_some() {
-            return Err(ProtocolError::WillAlreadySpecified);
+            return Err(ConfigError::DuplicateConfig);
         }
         self.will = Some(will);
         Ok(self)
@@ -215,7 +205,7 @@ mod tests {
         let mut buffer = [0; 30];
         assert!(matches!(
             Buffers::split(&mut buffer, 31),
-            Err(SetupError::BufferSplit)
+            Err(ConfigError::BufferSplit)
         ));
     }
 

--- a/src/fuzzing.rs
+++ b/src/fuzzing.rs
@@ -131,9 +131,15 @@ pub fn encode_packet(
                 publication = publication.correlate(BinaryData(b"id").0);
             }
 
-            let mut publish = crate::packets::Pub::from(publication);
-            publish.packet_id = (publish.qos > QoS::AtMostOnce).then_some(1);
-            let _ = MqttSerializer::pub_to_buffer(buf, publish);
+            let header = crate::packets::PublishHeader {
+                topic: crate::types::Utf8String(publication.topic),
+                packet_id: (publication.qos > QoS::AtMostOnce).then_some(1),
+                properties: publication.properties,
+                retain: publication.retain,
+                qos: publication.qos,
+                dup: false,
+            };
+            let _ = MqttSerializer::pub_to_buffer(buf, &header, publication.payload);
         }
         2 => {
             let topics = [TopicFilter::new(topic)];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ pub const MQTT_INSECURE_DEFAULT_PORT: u16 = 1883;
 /// Default port number for encrypted MQTT traffic.
 pub const MQTT_SECURE_DEFAULT_PORT: u16 = 8883;
 
+/// Fixed-capacity owned MQTT topic storage used by durable configuration.
+pub const TOPIC_CAPACITY: usize = 128;
+
+/// Fixed-capacity owned MQTT topic string.
+pub type TopicString = heapless::String<TOPIC_CAPACITY>;
+
 /// The quality-of-service for an MQTT message.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, TryFromPrimitive, PartialOrd, Ord)]
 #[repr(u8)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod types;
 mod varint;
 mod will;
 
-pub use config::{Buffers, ConfigBuilder, SetupError};
+pub use config::{Buffers, ConfigBuilder};
 pub use mqtt_client::{ConnectEvent, InboundPublish, Io, Op, OpStatus, Session};
 pub use properties::Property;
 pub use publication::{OwnedResponseTarget, Publication};
@@ -75,49 +75,158 @@ pub enum Retain {
     Retained = 1,
 }
 
-/// Errors that are specific to the MQTT protocol implementation.
+/// Configuration errors detected before a session is created.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
-pub enum ProtocolError {
+pub enum ConfigError {
+    /// The requested RX split does not fit in the provided backing buffer.
+    #[error("buffer split exceeds backing storage")]
+    BufferSplit,
     /// The configured client identifier exceeds the internal fixed-capacity storage.
     #[error("provided client ID is too long")]
-    ProvidedClientIdTooLong,
+    ClientIdTooLong,
+    /// One configuration setting was specified more than once.
+    #[error("configuration was specified more than once")]
+    DuplicateConfig,
+    /// The provided configuration is not valid for MQTT.
+    #[error("invalid MQTT configuration")]
+    InvalidConfig,
+}
+
+/// Failures caused by broker behavior or invalid inbound MQTT data.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum PeerError {
+    /// The broker explicitly rejected the operation with an MQTT reason code.
+    #[error("broker returned failure reason {0:?}")]
+    Rejected(ReasonCode),
+    /// The broker sent an invalid MQTT packet or protocol state transition.
+    #[error("received an invalid MQTT packet")]
+    InvalidPacket,
+}
+
+/// Local capacity and sizing failures.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ResourceError {
+    /// Local fixed-capacity storage or packet scratch space was too small.
+    #[error("buffer is too small")]
+    BufferTooSmall,
+    /// The requested or required packet exceeds the negotiated packet size limit.
+    #[error("packet is too large")]
+    PacketTooLarge,
+    /// Internal tracking space for in-flight packet metadata was exhausted.
+    #[error("in-flight metadata capacity exhausted")]
+    InflightExhausted,
+}
+
+/// Error returned from [`Session::publish`](crate::Session::publish).
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum PubError<P, E> {
+    /// Session, transport, peer, or local resource failure.
+    #[error(transparent)]
+    Session(#[from] Error<E>),
+    /// Payload serialization failed before the packet was sent.
+    #[error("payload serialization failed")]
+    Payload(P),
+}
+
+impl<P, E> From<crate::ser::PubError<P>> for PubError<P, E> {
+    fn from(e: crate::ser::PubError<P>) -> Self {
+        match e {
+            crate::ser::PubError::Payload(e) => Self::Payload(e),
+            crate::ser::PubError::Encode(e) => Self::Session(Error::from(e)),
+        }
+    }
+}
+
+impl<P, E> From<ProtocolError> for PubError<P, E> {
+    fn from(err: ProtocolError) -> Self {
+        Self::Session(err.into())
+    }
+}
+
+/// Possible errors encountered during MQTT operation.
+#[derive(Debug, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error<E> {
+    /// Local buffers or in-flight state are not currently ready for the requested operation.
+    #[error("session is not ready")]
+    NotReady,
+    /// The session is currently disconnected.
+    #[error("session is disconnected")]
+    Disconnected,
+    /// The requested operation arguments are not valid.
+    #[error("invalid request")]
+    InvalidRequest,
+    /// The broker rejected the operation or sent invalid MQTT data.
+    #[error(transparent)]
+    Peer(PeerError),
+    /// Local buffers or in-flight state were insufficient for the requested operation.
+    #[error(transparent)]
+    Resource(ResourceError),
+    /// Transport-layer failure during connect or I/O.
+    #[error("transport error: {0:?}")]
+    Transport(E),
+    /// A write operation returned `Ok(0)` for a non-empty buffer.
+    #[error("transport write returned zero bytes")]
+    WriteZero,
+}
+
+impl<E> From<ProtocolError> for Error<E> {
+    fn from(p: ProtocolError) -> Self {
+        match p {
+            ProtocolError::UnexpectedPacket
+            | ProtocolError::MalformedPacket
+            | ProtocolError::Deserialization(_) => Self::Peer(PeerError::InvalidPacket),
+            ProtocolError::InflightMetadataExhausted => {
+                Self::Resource(ResourceError::InflightExhausted)
+            }
+            ProtocolError::Failed(code) => match code {
+                ReasonCode::PacketTooLarge => Self::Resource(ResourceError::PacketTooLarge),
+                code => Self::Peer(PeerError::Rejected(code)),
+            },
+            ProtocolError::Encode(err) => Self::from(err),
+        }
+    }
+}
+
+impl<E> From<crate::ser::Error> for Error<E> {
+    fn from(err: crate::ser::Error) -> Self {
+        match err {
+            crate::ser::Error::InsufficientMemory => Self::Resource(ResourceError::BufferTooSmall),
+            crate::ser::Error::Custom => Self::InvalidRequest,
+        }
+    }
+}
+
+impl<E> From<crate::de::Error> for Error<E> {
+    fn from(err: crate::de::Error) -> Self {
+        let _ = err;
+        Self::Peer(PeerError::InvalidPacket)
+    }
+}
+
+impl<E> From<PeerError> for Error<E> {
+    fn from(err: PeerError) -> Self {
+        Self::Peer(err)
+    }
+}
+
+impl<E> From<ResourceError> for Error<E> {
+    fn from(err: ResourceError) -> Self {
+        Self::Resource(err)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub(crate) enum ProtocolError {
     /// The broker sent a packet that is invalid in the current protocol state.
     #[error("received an unexpected MQTT packet")]
     UnexpectedPacket,
-    /// A property was not valid for that packet type or operation.
-    #[error("received an invalid MQTT property")]
-    InvalidProperty,
     /// The broker sent malformed bytes.
     #[error("received a malformed MQTT packet")]
     MalformedPacket,
-    /// Fixed-capacity storage was too small for the requested value.
-    #[error("buffer is too small")]
-    BufferSize,
-    /// The requested RX/TX split exceeds the provided backing buffer.
-    #[error("invalid buffer split")]
-    BufferSplit,
-    /// The broker referred to an unknown packet identifier.
-    #[error("unknown packet identifier")]
-    BadIdentifier,
-    /// A QoS value was outside the MQTT-defined range.
-    #[error("invalid QoS value")]
-    WrongQos,
-    /// `minimq` does not implement that MQTT packet or feature.
-    #[error("unsupported MQTT packet")]
-    UnsupportedPacket,
-    /// An operation that requires at least one topic was called with none.
-    #[error("at least one topic is required")]
-    NoTopic,
-    /// Authentication was configured more than once.
-    #[error("authentication was already specified")]
-    AuthAlreadySpecified,
-    /// A will was configured more than once.
-    #[error("will message was already specified")]
-    WillAlreadySpecified,
-    /// The operation requires an active MQTT connection.
-    #[error("not connected")]
-    NotConnected,
     /// Internal tracking space for in-flight packet metadata was exhausted.
     #[error("in-flight metadata capacity exhausted")]
     InflightMetadataExhausted,
@@ -132,77 +241,9 @@ pub enum ProtocolError {
     Deserialization(#[from] DeError),
 }
 
-/// Error returned from [`Session::publish`](crate::Session::publish).
-#[derive(Debug, PartialEq, thiserror::Error)]
-pub enum PubError<P, E> {
-    /// Session setup, transport, or protocol failure.
-    #[error(transparent)]
-    Session(#[from] Error<E>),
-    /// Payload serialization failed before the packet was sent.
-    #[error("payload serialization failed")]
-    Payload(P),
-}
-
-impl<P, E> From<crate::ser::PubError<P>> for PubError<P, E> {
-    fn from(e: crate::ser::PubError<P>) -> Self {
-        match e {
-            crate::ser::PubError::Payload(e) => Self::Payload(e),
-            crate::ser::PubError::Encode(e) => Self::Session(ProtocolError::from(e).into()),
-        }
-    }
-}
-
-impl<P, E> From<ProtocolError> for PubError<P, E> {
-    fn from(err: ProtocolError) -> Self {
-        Self::Session(err.into())
-    }
-}
-
 impl From<ReasonCode> for ProtocolError {
     fn from(code: ReasonCode) -> Self {
         Self::Failed(code)
-    }
-}
-
-/// Possible errors encountered during MQTT operation.
-#[derive(Debug, PartialEq, thiserror::Error)]
-#[non_exhaustive]
-pub enum Error<E> {
-    /// Local buffers or in-flight state are not currently ready for the requested operation.
-    #[error("session is not ready")]
-    NotReady,
-    /// The session is currently disconnected.
-    #[error("session is disconnected")]
-    Disconnected,
-    /// MQTT protocol-level failure.
-    #[error(transparent)]
-    Protocol(ProtocolError),
-    /// Transport-layer failure during connect or I/O.
-    #[error("transport error: {0:?}")]
-    Transport(E),
-    /// A write operation returned `Ok(0)` for a non-empty buffer.
-    #[error("transport write returned zero bytes")]
-    WriteZero,
-}
-
-impl<E> From<ProtocolError> for Error<E> {
-    fn from(p: ProtocolError) -> Self {
-        match p {
-            ProtocolError::NotConnected => Self::Disconnected,
-            other => Self::Protocol(other),
-        }
-    }
-}
-
-impl<E> From<crate::ser::Error> for Error<E> {
-    fn from(err: crate::ser::Error) -> Self {
-        ProtocolError::from(err).into()
-    }
-}
-
-impl<E> From<crate::de::Error> for Error<E> {
-    fn from(err: crate::de::Error) -> Self {
-        ProtocolError::from(err).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod varint;
 mod will;
 
 pub use config::{Buffers, ConfigBuilder, SetupError};
-pub use mqtt_client::{ConnectEvent, InboundPublish, Io, Session};
+pub use mqtt_client::{ConnectEvent, InboundPublish, Io, Op, OpStatus, Session};
 pub use properties::Property;
 pub use publication::{OwnedResponseTarget, Publication};
 pub use reason_codes::ReasonCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,7 @@
 pub mod config;
 mod de;
 mod message_types;
-/// Long-lived MQTT client session types.
-pub mod mqtt_client;
+mod mqtt_client;
 mod packets;
 mod properties;
 /// Outbound publish builders and payload adapters.
@@ -29,8 +28,8 @@ pub use will::Will;
 #[doc(hidden)]
 pub mod fuzzing;
 
-pub use de::Error as DeError;
-pub use ser::Error as SerError;
+use de::Error as DeError;
+use ser::Error as SerError;
 
 use num_enum::TryFromPrimitive;
 
@@ -121,10 +120,10 @@ pub enum ProtocolError {
     Failed(ReasonCode),
     /// Packet encoding failed.
     #[error(transparent)]
-    Encode(SerError),
+    Encode(#[from] SerError),
     /// Packet decoding failed.
     #[error(transparent)]
-    Deserialization(DeError),
+    Deserialization(#[from] DeError),
 }
 
 /// Error returned from [`Session::publish`](crate::Session::publish).
@@ -147,15 +146,9 @@ impl<P, E> From<crate::ser::PubError<P>> for PubError<P, E> {
     }
 }
 
-impl From<crate::ser::Error> for ProtocolError {
-    fn from(err: crate::ser::Error) -> Self {
-        Self::Encode(err)
-    }
-}
-
-impl From<crate::de::Error> for ProtocolError {
-    fn from(err: crate::de::Error) -> Self {
-        Self::Deserialization(err)
+impl<P, E> From<ProtocolError> for PubError<P, E> {
+    fn from(err: ProtocolError) -> Self {
+        Self::Session(err.into())
     }
 }
 
@@ -192,6 +185,18 @@ impl<E> From<ProtocolError> for Error<E> {
             ProtocolError::NotConnected => Self::Disconnected,
             other => Self::Protocol(other),
         }
+    }
+}
+
+impl<E> From<crate::ser::Error> for Error<E> {
+    fn from(err: crate::ser::Error) -> Self {
+        ProtocolError::from(err).into()
+    }
+}
+
+impl<E> From<crate::de::Error> for Error<E> {
+    fn from(err: crate::de::Error) -> Self {
+        ProtocolError::from(err).into()
     }
 }
 

--- a/src/message_types.rs
+++ b/src/message_types.rs
@@ -1,8 +1,8 @@
 use crate::{
     Retain,
     packets::{
-        ConnAck, Connect, Disconnect, DisconnectReq, PingReq, PingResp, Pub, PubAck, PubComp,
-        PubRec, PubRel, SubAck, Subscribe, UnsubAck, Unsubscribe,
+        ConnAck, Connect, Disconnect, DisconnectReq, PingReq, PingResp, PubAck, PubComp, PubRec,
+        PubRel, PublishHeader, SubAck, Subscribe, UnsubAck, Unsubscribe,
     },
 };
 use bit_field::BitField;
@@ -43,7 +43,7 @@ impl ControlPacket for ConnAck<'_> {
     const MESSAGE_TYPE: MessageType = MessageType::ConnAck;
 }
 
-impl<P> Pub<'_, P> {
+impl PublishHeader<'_> {
     pub fn fixed_header_flags(&self) -> u8 {
         *0u8.set_bits(1..=2, self.qos as u8)
             .set_bit(0, self.retain == Retain::Retained)

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -4,7 +4,7 @@ mod session;
 pub use session::Session;
 
 use crate::{
-    ProtocolError, QoS, Retain,
+    QoS, ResourceError, Retain,
     publication::{OwnedResponseTarget, Publication, ResponseTarget},
     types::Properties,
 };
@@ -139,7 +139,7 @@ impl<'a> InboundPublish<'a> {
     /// Use this when the reply has to outlive the borrowed inbound packet.
     pub fn reply_owned<const TOPIC: usize, const CORRELATION: usize>(
         &'a self,
-    ) -> Result<Option<OwnedResponseTarget<TOPIC, CORRELATION>>, ProtocolError> {
+    ) -> Result<Option<OwnedResponseTarget<TOPIC, CORRELATION>>, ResourceError> {
         self.response_target()
             .map(ResponseTarget::to_owned)
             .transpose()

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -121,13 +121,17 @@ impl<'a> InboundPublish<'a> {
         self.properties.correlation_data()
     }
 
-    /// Build a direct reply publication when the inbound message carries a response topic.
-    pub fn reply<P>(&'a self, payload: P) -> Option<Publication<'a, P>> {
+    fn response_target(&'a self) -> Option<ResponseTarget<'a>> {
         Some(ResponseTarget {
             topic: self.response_topic()?,
             correlation_data: self.correlation_data(),
         })
-        .map(|target| target.publication(payload))
+    }
+
+    /// Build a direct reply publication when the inbound message carries a response topic.
+    pub fn reply<P>(&'a self, payload: P) -> Option<Publication<'a, P>> {
+        self.response_target()
+            .map(|target| target.publication(payload))
     }
 
     /// Copy the response target into fixed-capacity owned storage.
@@ -136,15 +140,9 @@ impl<'a> InboundPublish<'a> {
     pub fn reply_owned<const TOPIC: usize, const CORRELATION: usize>(
         &'a self,
     ) -> Result<Option<OwnedResponseTarget<TOPIC, CORRELATION>>, ProtocolError> {
-        match self.response_topic() {
-            Some(topic) => ResponseTarget {
-                topic,
-                correlation_data: self.correlation_data(),
-            }
-            .to_owned()
-            .map(Some),
-            None => Ok(None),
-        }
+        self.response_target()
+            .map(ResponseTarget::to_owned)
+            .transpose()
     }
 }
 

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -19,7 +19,47 @@ pub trait Io: Read + Write + ErrorType {}
 
 impl<T> Io for T where T: Read + Write + ErrorType {}
 
-/// Inbound MQTT `PUBLISH` returned by [`Session::poll`](crate::Session::poll).
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum OpKind {
+    PublishAtLeastOnce,
+    PublishExactlyOnce,
+    Subscribe,
+    Unsubscribe,
+}
+
+/// Handle for one outbound MQTT operation accepted into local session state.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Op {
+    kind: OpKind,
+    packet_id: u16,
+    generation: u32,
+}
+
+impl Op {
+    pub(crate) fn new(kind: OpKind, packet_id: u16, generation: u32) -> Self {
+        Self {
+            kind,
+            packet_id,
+            generation,
+        }
+    }
+}
+
+/// Completion state of a previously accepted outbound operation.
+#[must_use = "inspect the returned status before deciding how to proceed"]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum OpStatus {
+    /// The operation is still present in local in-flight state.
+    Pending,
+    /// The operation is no longer pending in this session generation.
+    Complete,
+    /// The local session state that could complete this operation was discarded.
+    Invalidated,
+}
+
+/// Inbound MQTT `PUBLISH` surfaced by [`Session::recv`](crate::Session::recv) and by
+/// [`Session::drive`](crate::Session::drive) / [`Session::poll`](crate::Session::poll) when they
+/// return `Some(...)`.
 #[derive(Debug)]
 pub struct InboundPublish<'a> {
     topic: &'a str,

--- a/src/mqtt_client/outbound.rs
+++ b/src/mqtt_client/outbound.rs
@@ -1,7 +1,7 @@
 use crate::packets::PublishHeader;
 use crate::packets::{PingReq, PubAck, PubComp, PubRec, PubRel};
 use crate::ser::MAX_FIXED_HEADER_SIZE;
-use crate::{Error, ProtocolError, PubError, ReasonCode, error, trace};
+use crate::{Error, ProtocolError, PubError, ReasonCode, ResourceError, error, trace};
 use heapless::Vec;
 
 use super::Io;
@@ -458,9 +458,7 @@ pub(super) fn serialize_control_packet<E>(
 ) -> Result<&[u8], Error<E>> {
     let bytes = encode_control_packet(buffer, packet)?;
     if maximum_packet_size.is_some_and(|max| bytes.len() > max as usize) {
-        return Err(Error::Protocol(ProtocolError::Failed(
-            ReasonCode::PacketTooLarge,
-        )));
+        return Err(Error::Resource(ResourceError::PacketTooLarge));
     }
     Ok(bytes)
 }
@@ -526,9 +524,7 @@ pub(super) fn serialize_pubrel<E>(
 ) -> Result<&[u8], Error<E>> {
     let bytes = encode_pubrel(buffer, packet_id, reason)?;
     if maximum_packet_size.is_some_and(|max| bytes.len() > max as usize) {
-        return Err(Error::Protocol(ProtocolError::Failed(
-            ReasonCode::PacketTooLarge,
-        )));
+        return Err(Error::Resource(ResourceError::PacketTooLarge));
     }
     Ok(bytes)
 }
@@ -634,8 +630,8 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(crate::PubError::Session(crate::Error::Protocol(
-                crate::ProtocolError::Encode(crate::SerError::InsufficientMemory)
+            Err(crate::PubError::Session(crate::Error::Resource(
+                crate::ResourceError::BufferTooSmall
             )))
         ));
     }

--- a/src/mqtt_client/outbound.rs
+++ b/src/mqtt_client/outbound.rs
@@ -205,6 +205,12 @@ impl<'a> Outbound<'a> {
         true
     }
 
+    pub(super) fn has_retained(&self, packet_id: u16) -> bool {
+        self.retained
+            .iter()
+            .any(|entry| entry.packet_id == packet_id)
+    }
+
     pub(super) fn queue_release(
         &mut self,
         packet_id: u16,

--- a/src/mqtt_client/outbound.rs
+++ b/src/mqtt_client/outbound.rs
@@ -1,4 +1,4 @@
-use crate::packets::Pub;
+use crate::packets::PublishHeader;
 use crate::packets::{PingReq, PubAck, PubComp, PubRec, PubRel};
 use crate::ser::MAX_FIXED_HEADER_SIZE;
 use crate::{Error, ProtocolError, PubError, ReasonCode, error, trace};
@@ -245,18 +245,16 @@ impl<'a> Outbound<'a> {
 
     pub(super) fn encode_publish<P: crate::publication::ToPayload, E>(
         &mut self,
-        packet: Pub<'_, P>,
+        header: &PublishHeader<'_>,
+        payload: P,
     ) -> Result<(usize, usize), PubError<P::Error, E>> {
         self.compact();
         let start = self.used;
-        let (offset, packet) =
-            crate::ser::MqttSerializer::pub_to_buffer_meta(&mut self.buf[start..], packet)
-                .map_err(|err| match err {
-                    crate::ser::PubError::Encode(err) => {
-                        PubError::Session(Error::Protocol(err.into()))
-                    }
-                    crate::ser::PubError::Payload(err) => PubError::Payload(err),
-                })?;
+        let (offset, packet) = crate::ser::MqttSerializer::pub_to_buffer_meta(
+            &mut self.buf[start..],
+            header,
+            payload,
+        )?;
         Ok((start + offset, packet.len()))
     }
 
@@ -267,8 +265,7 @@ impl<'a> Outbound<'a> {
         self.compact();
         let start = self.used;
         let (offset, packet) =
-            crate::ser::MqttSerializer::to_buffer_meta(&mut self.buf[start..], packet)
-                .map_err(ProtocolError::from)?;
+            crate::ser::MqttSerializer::to_buffer_meta(&mut self.buf[start..], packet)?;
         Ok((start + offset, packet.len()))
     }
 
@@ -453,7 +450,7 @@ pub(super) fn serialize_control_packet<E>(
     packet: ControlAction,
     maximum_packet_size: Option<u32>,
 ) -> Result<&[u8], Error<E>> {
-    let bytes = encode_control_packet(buffer, packet).map_err(Error::Protocol)?;
+    let bytes = encode_control_packet(buffer, packet)?;
     if maximum_packet_size.is_some_and(|max| bytes.len() > max as usize) {
         return Err(Error::Protocol(ProtocolError::Failed(
             ReasonCode::PacketTooLarge,
@@ -463,7 +460,7 @@ pub(super) fn serialize_control_packet<E>(
 }
 
 fn encode_control_packet(buffer: &mut [u8], packet: ControlAction) -> Result<&[u8], ProtocolError> {
-    match packet {
+    Ok(match packet {
         ControlAction::PubAck { packet_id, reason } => crate::ser::MqttSerializer::to_buffer(
             buffer,
             &PubAck {
@@ -486,8 +483,7 @@ fn encode_control_packet(buffer: &mut [u8], packet: ControlAction) -> Result<&[u
             },
         ),
         ControlAction::PingReq => crate::ser::MqttSerializer::to_buffer(buffer, &PingReq),
-    }
-    .map_err(ProtocolError::from)
+    }?)
 }
 
 fn require_packet_size(maximum_packet_size: Option<u32>, len: usize) -> Result<(), ProtocolError> {
@@ -522,7 +518,7 @@ pub(super) fn serialize_pubrel<E>(
     reason: ReasonCode,
     maximum_packet_size: Option<u32>,
 ) -> Result<&[u8], Error<E>> {
-    let bytes = encode_pubrel(buffer, packet_id, reason).map_err(Error::Protocol)?;
+    let bytes = encode_pubrel(buffer, packet_id, reason)?;
     if maximum_packet_size.is_some_and(|max| bytes.len() > max as usize) {
         return Err(Error::Protocol(ProtocolError::Failed(
             ReasonCode::PacketTooLarge,
@@ -536,14 +532,13 @@ fn encode_pubrel(
     packet_id: u16,
     reason: ReasonCode,
 ) -> Result<&[u8], ProtocolError> {
-    crate::ser::MqttSerializer::to_buffer(
+    Ok(crate::ser::MqttSerializer::to_buffer(
         buffer,
         &PubRel {
             packet_id,
             reason: reason.into(),
         },
-    )
-    .map_err(ProtocolError::from)
+    )?)
 }
 
 pub(super) async fn write_packet<C: Io, T>(
@@ -554,8 +549,7 @@ pub(super) async fn write_packet<C: Io, T>(
 where
     T: serde::Serialize + crate::message_types::ControlPacket + core::fmt::Debug,
 {
-    let bytes = crate::ser::MqttSerializer::to_buffer(buffer, packet)
-        .map_err(|err| Error::Protocol(err.into()))?;
+    let bytes = crate::ser::MqttSerializer::to_buffer(buffer, packet)?;
     write_all(connection, bytes).await?;
     connection.flush().await.map_err(Error::Transport)?;
     Ok(())
@@ -621,8 +615,16 @@ mod tests {
 
         outbound.retain_packet(7, 0, 5).unwrap();
 
-        let result = outbound
-            .encode_publish::<_, ()>(crate::packets::Pub::from(Publication::bytes("a", b"x")));
+        let publication = Publication::bytes("a", b"x");
+        let header = crate::packets::PublishHeader {
+            topic: crate::types::Utf8String(publication.topic),
+            packet_id: None,
+            properties: publication.properties,
+            retain: publication.retain,
+            qos: publication.qos,
+            dup: false,
+        };
+        let result = outbound.encode_publish::<_, ()>(&header, publication.payload);
 
         assert!(matches!(
             result,

--- a/src/mqtt_client/session/drive.rs
+++ b/src/mqtt_client/session/drive.rs
@@ -8,7 +8,7 @@ use super::super::outbound::{
     ControlAction, OutboundStep, SendState, check_control_packet_size, serialize_control_packet,
     serialize_pubrel,
 };
-use super::state::PING_TIMEOUT_MS;
+use super::state::ROUND_TRIP_TIMEOUT_MS;
 use super::{Io, Session};
 
 #[derive(Copy, Clone)]
@@ -16,6 +16,13 @@ enum FlushedPacket {
     Control(ControlAction),
     Release(u16),
     Retained(u16),
+}
+
+#[derive(Copy, Clone)]
+enum Progress {
+    Idle,
+    Advanced,
+    Inbound(usize),
 }
 
 pub(super) async fn fill_packet_reader<'buf, C: Io>(
@@ -46,31 +53,42 @@ impl<'buf, IO> Session<'buf, IO>
 where
     IO: Io,
 {
-    async fn drive_packet(&mut self) -> Result<Option<usize>, Error<IO::Error>> {
+    async fn drive_packet(&mut self) -> Result<Progress, Error<IO::Error>> {
         if self.connection.is_none() {
             return Err(Error::Disconnected);
         }
 
+        let mut advanced = false;
         loop {
             if self.packet_reader.packet_available() {
                 match self.process_received_packet()? {
-                    Some(packet_length) => return Ok(Some(packet_length)),
-                    None => continue,
+                    Some(packet_length) => return Ok(Progress::Inbound(packet_length)),
+                    None => {
+                        advanced = true;
+                        continue;
+                    }
                 }
             }
 
             let now = Instant::now();
-            self.service(now).await?;
+            advanced |= self.service(now).await?;
 
             if self.packet_reader.packet_available() {
                 match self.process_received_packet()? {
-                    Some(packet_length) => return Ok(Some(packet_length)),
-                    None => continue,
+                    Some(packet_length) => return Ok(Progress::Inbound(packet_length)),
+                    None => {
+                        advanced = true;
+                        continue;
+                    }
                 }
             }
 
             if self.data.outbound.next_step().is_none() {
-                return Ok(None);
+                return Ok(if advanced {
+                    Progress::Advanced
+                } else {
+                    Progress::Idle
+                });
             }
         }
     }
@@ -78,25 +96,43 @@ where
     /// Advance local session state until an inbound publish is ready or the session would need to
     /// wait for new transport input or a future deadline.
     ///
-    /// Returns `Ok(None)` when no inbound publish is currently ready and the caller would need to
-    /// block for more progress. Cancel-safe if the underlying transport I/O futures are
-    /// cancel-safe.
+    /// This is a cooperative progress step:
+    /// - it does not wait for future inbound reads
+    /// - it does not wait for future session deadlines
+    /// - it may still await transport write or flush progress already needed for the current step
+    ///
+    /// Returns `Ok(None)` when no inbound publish is currently ready and further progress would
+    /// require waiting. Wall-clock bounds depend on the transport: a stalled write or flush may
+    /// still keep this future pending until the transport errors or is cancelled. Cancel-safe if
+    /// the underlying transport I/O futures are cancel-safe.
     pub async fn drive(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        Ok(self
-            .drive_packet()
-            .await?
-            .map(|packet_length| self.decode_inbound_publish(packet_length)))
+        Ok(match self.drive_packet().await? {
+            Progress::Inbound(packet_length) => Some(self.decode_inbound_publish(packet_length)),
+            Progress::Idle | Progress::Advanced => None,
+        })
     }
 
-    /// Wait until an inbound publish arrives or the session disconnects.
+    /// Wait until any session progress happens or the session disconnects.
+    ///
+    /// Returns:
+    /// - `Ok(Some(msg))` when that progress produced an inbound publish
+    /// - `Ok(None)` when progress happened only internally, such as ACK handling, replay, or
+    ///   keepalive traffic
+    ///
+    /// As with [`drive`](Self::drive), wall-clock bounds depend on the transport's read, write,
+    /// and flush behavior.
     ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe. Ordinary no-data must
     /// be represented by the transport future staying pending; `TimedOut` and `Interrupted` are
     /// treated as transport failure and disconnect the session.
-    pub async fn poll(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
+    pub async fn poll(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
         loop {
-            if let Some(packet_length) = self.drive_packet().await? {
-                return Ok(self.decode_inbound_publish(packet_length));
+            match self.drive_packet().await? {
+                Progress::Inbound(packet_length) => {
+                    return Ok(Some(self.decode_inbound_publish(packet_length)));
+                }
+                Progress::Advanced => return Ok(None),
+                Progress::Idle => {}
             }
 
             let deadline = self.runtime.next_deadline();
@@ -112,7 +148,34 @@ where
         }
     }
 
-    pub(super) async fn service(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
+    /// Wait until the next inbound publish arrives.
+    ///
+    /// This is a convenience wrapper over [`poll`](Self::poll) that skips internal-only
+    /// progress.
+    pub async fn recv(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
+        loop {
+            match self.drive_packet().await? {
+                Progress::Inbound(packet_length) => {
+                    return Ok(self.decode_inbound_publish(packet_length));
+                }
+                Progress::Advanced => continue,
+                Progress::Idle => {}
+            }
+
+            let deadline = self.runtime.next_deadline();
+            let read = self.read_packet();
+            match deadline {
+                Some(deadline) => match with_deadline(deadline, read).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(err)) => return Err(err),
+                    Err(_) => continue,
+                },
+                None => read.await?,
+            }
+        }
+    }
+
+    pub(super) async fn service(&mut self, now: Instant) -> Result<bool, Error<IO::Error>> {
         if self
             .runtime
             .ping_timeout
@@ -162,17 +225,17 @@ where
         Ok(())
     }
 
-    async fn service_outbound_once(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
+    async fn service_outbound_once(&mut self, now: Instant) -> Result<bool, Error<IO::Error>> {
         self.maybe_queue_pingreq(now)?;
         let Some(step) = self.data.outbound.next_step() else {
-            return Ok(());
+            return Ok(false);
         };
         self.perform_outbound_step(step, now).await
     }
 
     fn complete_flush(&mut self, packet: FlushedPacket, now: Instant) {
         if matches!(packet, FlushedPacket::Control(ControlAction::PingReq)) {
-            self.runtime.ping_timeout = Some(now + Duration::from_millis(PING_TIMEOUT_MS));
+            self.runtime.ping_timeout = Some(now + Duration::from_millis(ROUND_TRIP_TIMEOUT_MS));
         }
         self.runtime.note_outbound_activity(now);
         match packet {
@@ -186,7 +249,7 @@ where
         &mut self,
         step: OutboundStep,
         now: Instant,
-    ) -> Result<(), Error<IO::Error>> {
+    ) -> Result<bool, Error<IO::Error>> {
         macro_rules! write_or_disconnect {
             ($res:expr, $write_failed:literal) => {
                 match $res {
@@ -242,7 +305,7 @@ where
                         packet.len(),
                     );
                     if written + count < packet.len() {
-                        return Ok(());
+                        return Ok(true);
                     }
                     trace!("Flushing control packet {:?}", step.action);
                     let res = {
@@ -251,6 +314,7 @@ where
                     };
                     flush_or_disconnect!(res, "Control packet flush failed: {:?}");
                     self.complete_flush(FlushedPacket::Control(step.action), now);
+                    Ok(true)
                 }
                 SendState::Flush => {
                     trace!("Flushing control packet {:?}", step.action);
@@ -260,8 +324,9 @@ where
                     };
                     flush_or_disconnect!(res, "Control packet flush failed: {:?}");
                     self.complete_flush(FlushedPacket::Control(step.action), now);
+                    Ok(true)
                 }
-                SendState::Sent => {}
+                SendState::Sent => Ok(false),
             },
             OutboundStep::Release(step) => match step.state {
                 SendState::Write { written } => {
@@ -290,7 +355,7 @@ where
                         packet.len(),
                     );
                     if written + count < packet.len() {
-                        return Ok(());
+                        return Ok(true);
                     }
                     trace!("Flushing PUBREL packet packet_id={}", step.packet_id);
                     let res = {
@@ -299,6 +364,7 @@ where
                     };
                     flush_or_disconnect!(res, "PUBREL flush failed: {:?}");
                     self.complete_flush(FlushedPacket::Release(step.packet_id), now);
+                    Ok(true)
                 }
                 SendState::Flush => {
                     trace!("Flushing PUBREL packet packet_id={}", step.packet_id);
@@ -308,8 +374,9 @@ where
                     };
                     flush_or_disconnect!(res, "PUBREL flush failed: {:?}");
                     self.complete_flush(FlushedPacket::Release(step.packet_id), now);
+                    Ok(true)
                 }
-                SendState::Sent => {}
+                SendState::Sent => Ok(false),
             },
             OutboundStep::Retained(step) => match step.state {
                 SendState::Write { written } => {
@@ -337,7 +404,7 @@ where
                         step.len,
                     );
                     if written + count < step.len {
-                        return Ok(());
+                        return Ok(true);
                     }
                     debug!("Flushing retained packet packet_id={}", step.packet_id);
                     let res = {
@@ -346,6 +413,7 @@ where
                     };
                     flush_or_disconnect!(res, "Retained packet flush failed: {:?}");
                     self.complete_flush(FlushedPacket::Retained(step.packet_id), now);
+                    Ok(true)
                 }
                 SendState::Flush => {
                     debug!("Flushing retained packet packet_id={}", step.packet_id);
@@ -355,11 +423,11 @@ where
                     };
                     flush_or_disconnect!(res, "Retained packet flush failed: {:?}");
                     self.complete_flush(FlushedPacket::Retained(step.packet_id), now);
+                    Ok(true)
                 }
-                SendState::Sent => {}
+                SendState::Sent => Ok(false),
             },
         }
-        Ok(())
     }
 
     pub(super) fn handle_disconnect(&mut self) {

--- a/src/mqtt_client/session/drive.rs
+++ b/src/mqtt_client/session/drive.rs
@@ -23,7 +23,7 @@ pub(super) async fn fill_packet_reader<'buf, C: Io>(
     connection: &mut C,
 ) -> Result<(), Error<C::Error>> {
     while !packet_reader.packet_available() {
-        let buffer = packet_reader.receive_buffer().map_err(Error::Protocol)?;
+        let buffer = packet_reader.receive_buffer()?;
         if buffer.is_empty() {
             break;
         }
@@ -140,12 +140,8 @@ where
 
     fn maybe_queue_pingreq(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
         if self.should_queue_pingreq(now) {
-            check_control_packet_size(self.runtime.maximum_packet_size, ControlAction::PingReq)
-                .map_err(Error::Protocol)?;
-            self.data
-                .outbound
-                .queue_control(ControlAction::PingReq)
-                .map_err(Error::Protocol)?;
+            check_control_packet_size(self.runtime.maximum_packet_size, ControlAction::PingReq)?;
+            self.data.outbound.queue_control(ControlAction::PingReq)?;
         }
         Ok(())
     }

--- a/src/mqtt_client/session/drive.rs
+++ b/src/mqtt_client/session/drive.rs
@@ -126,12 +126,22 @@ where
     /// be represented by the transport future staying pending; `TimedOut` and `Interrupted` are
     /// treated as transport failure and disconnect the session.
     pub async fn poll(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        match self.wait_for_progress().await? {
+            Progress::Inbound(packet_length) => {
+                Ok(Some(self.decode_inbound_publish(packet_length)))
+            }
+            Progress::Advanced => Ok(None),
+            Progress::Idle => unreachable!("wait_for_progress only returns after session progress"),
+        }
+    }
+
+    async fn wait_for_progress(&mut self) -> Result<Progress, Error<IO::Error>> {
         loop {
             match self.drive_packet().await? {
                 Progress::Inbound(packet_length) => {
-                    return Ok(Some(self.decode_inbound_publish(packet_length)));
+                    return Ok(Progress::Inbound(packet_length));
                 }
-                Progress::Advanced => return Ok(None),
+                Progress::Advanced => return Ok(Progress::Advanced),
                 Progress::Idle => {}
             }
 
@@ -154,23 +164,14 @@ where
     /// progress.
     pub async fn recv(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
         loop {
-            match self.drive_packet().await? {
+            match self.wait_for_progress().await? {
                 Progress::Inbound(packet_length) => {
                     return Ok(self.decode_inbound_publish(packet_length));
                 }
-                Progress::Advanced => continue,
-                Progress::Idle => {}
-            }
-
-            let deadline = self.runtime.next_deadline();
-            let read = self.read_packet();
-            match deadline {
-                Some(deadline) => match with_deadline(deadline, read).await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(err)) => return Err(err),
-                    Err(_) => continue,
-                },
-                None => read.await?,
+                Progress::Advanced => {}
+                Progress::Idle => {
+                    unreachable!("wait_for_progress only returns after session progress")
+                }
             }
         }
     }

--- a/src/mqtt_client/session/handshake.rs
+++ b/src/mqtt_client/session/handshake.rs
@@ -1,8 +1,5 @@
-use core::convert::TryFrom;
-
 use embassy_time::{Duration, Instant};
 use embedded_io_async::Error as _;
-use heapless::String;
 
 use crate::de::received_packet::ReceivedPacket;
 use crate::packets::Connect;
@@ -141,7 +138,7 @@ where
             } {
                 Property::MaximumPacketSize(size) => maximum_packet_size = Some(size),
                 Property::AssignedClientIdentifier(id) => {
-                    assigned_client_id = Some(match String::try_from(id.0) {
+                    assigned_client_id = Some(match id.0.try_into() {
                         Ok(client_id) => client_id,
                         Err(_) => {
                             self.handle_disconnect();

--- a/src/mqtt_client/session/handshake.rs
+++ b/src/mqtt_client/session/handshake.rs
@@ -4,7 +4,7 @@ use embedded_io_async::Error as _;
 use crate::de::received_packet::ReceivedPacket;
 use crate::packets::Connect;
 use crate::types::{Properties, Utf8String};
-use crate::{Error, Property, ProtocolError, QoS, debug, info, warn};
+use crate::{Error, PeerError, Property, QoS, debug, info, warn};
 
 use super::super::ConnectEvent;
 use super::super::outbound::write_packet;
@@ -104,14 +104,14 @@ where
             }
             _ => {
                 self.handle_disconnect();
-                return Err(Error::Protocol(ProtocolError::UnexpectedPacket));
+                return Err(Error::Peer(PeerError::InvalidPacket));
             }
         };
 
         if let Err(err) = ack.reason_code.as_result() {
             warn!("Broker rejected CONNECT with reason {:?}", ack.reason_code);
             self.handle_disconnect();
-            return Err(Error::Protocol(err));
+            return Err(Error::Peer(err));
         }
 
         let resumed = ack.session_present;
@@ -133,7 +133,7 @@ where
                 Ok(property) => property,
                 Err(err) => {
                     self.handle_disconnect();
-                    return Err(Error::Protocol(err));
+                    return Err(Error::Peer(err));
                 }
             } {
                 Property::MaximumPacketSize(size) => maximum_packet_size = Some(size),
@@ -142,7 +142,7 @@ where
                         Ok(client_id) => client_id,
                         Err(_) => {
                             self.handle_disconnect();
-                            return Err(Error::Protocol(ProtocolError::ProvidedClientIdTooLong));
+                            return Err(Error::Peer(PeerError::InvalidPacket));
                         }
                     });
                 }
@@ -152,7 +152,7 @@ where
                 Property::ReceiveMaximum(max) => {
                     if max == 0 {
                         self.handle_disconnect();
-                        return Err(Error::Protocol(ProtocolError::InvalidProperty));
+                        return Err(Error::Peer(PeerError::InvalidPacket));
                     }
                     send_quota = max.min(local_quota);
                     max_send_quota = max.min(local_quota);
@@ -162,7 +162,7 @@ where
                         Ok(qos) => qos,
                         Err(_) => {
                             self.handle_disconnect();
-                            return Err(Error::Protocol(ProtocolError::WrongQos));
+                            return Err(Error::Peer(PeerError::InvalidPacket));
                         }
                     });
                 }

--- a/src/mqtt_client/session/inbound.rs
+++ b/src/mqtt_client/session/inbound.rs
@@ -1,7 +1,10 @@
 use core::convert::Infallible;
 
 use crate::de::received_packet::ReceivedPacket;
-use crate::{Error, InboundPublish, ProtocolError, QoS, ReasonCode, debug, info, trace, warn};
+use crate::{
+    Error, InboundPublish, PeerError, ProtocolError, QoS, ReasonCode, ResourceError, debug, info,
+    trace, warn,
+};
 
 use super::super::outbound::{ControlAction, check_control_packet_size, check_pubrel_size};
 use super::state::{RuntimeState, SessionData};
@@ -222,26 +225,19 @@ where
                 self.handle_disconnect();
                 Err(Error::Disconnected)
             }
-            Err(Error::Protocol(err))
-                if matches!(
-                    err,
-                    ProtocolError::MalformedPacket
-                        | ProtocolError::UnexpectedPacket
-                        | ProtocolError::InvalidProperty
-                        | ProtocolError::ProvidedClientIdTooLong
-                        | ProtocolError::WrongQos
-                        | ProtocolError::UnsupportedPacket
-                        | ProtocolError::BadIdentifier
-                        | ProtocolError::Deserialization(_)
-                        | ProtocolError::Failed(ReasonCode::PacketTooLarge)
-                ) =>
-            {
+            Err(Error::Peer(PeerError::InvalidPacket)) => {
                 warn!("Disconnecting session after packet handling error");
                 self.handle_disconnect();
-                Err(Error::Protocol(err))
+                Err(Error::Peer(PeerError::InvalidPacket))
             }
-            Err(Error::Protocol(err)) => Err(Error::Protocol(err)),
-            Err(Error::NotReady | Error::WriteZero) => {
+            Err(Error::Resource(ResourceError::PacketTooLarge)) => {
+                warn!("Disconnecting session after packet handling error");
+                self.handle_disconnect();
+                Err(Error::Resource(ResourceError::PacketTooLarge))
+            }
+            Err(Error::Peer(err)) => Err(Error::Peer(err)),
+            Err(Error::Resource(err)) => Err(Error::Resource(err)),
+            Err(Error::InvalidRequest | Error::NotReady | Error::WriteZero) => {
                 unreachable!("packet handler returned local I/O state")
             }
             Err(Error::Transport(never)) => match never {},

--- a/src/mqtt_client/session/mod.rs
+++ b/src/mqtt_client/session/mod.rs
@@ -10,7 +10,7 @@ mod tests;
 use crate::de::PacketReader;
 use crate::ser::MAX_FIXED_HEADER_SIZE;
 use crate::types::Auth;
-use crate::{ConfigBuilder, QoS, Will};
+use crate::{ConfigBuilder, Op, OpStatus, QoS, Will};
 use heapless::String;
 
 use super::Io;
@@ -19,12 +19,15 @@ use state::{RuntimeState, SessionData};
 
 /// One long-lived MQTT client session.
 ///
-/// Drive the session by calling [`poll`](Self::poll) regularly after
-/// [`connect`](Self::connect) has taken ownership of a live transport. The same session is also
-/// used for outbound `publish`, `subscribe`, and `unsubscribe` operations.
+/// Drive the session after [`connect`](Self::connect) has taken ownership of a live transport.
+/// Use [`recv`](Self::recv) when you want the next inbound publish, [`poll`](Self::poll) when you
+/// need to wait for any session progress, and [`drive`](Self::drive) for cooperative immediate
+/// progress. Real time bounds come from the transport: stalled reads, writes, or flushes must
+/// eventually error if the caller needs hard latency limits. The same session is also used for
+/// outbound `publish`, `subscribe`, and `unsubscribe` operations.
 ///
 /// Cancel safety, assuming the transport's I/O futures are cancel-safe:
-/// [`drive`](Self::drive), [`poll`](Self::poll), [`disconnect`](Self::disconnect),
+/// [`drive`](Self::drive), [`poll`](Self::poll), [`recv`](Self::recv), [`disconnect`](Self::disconnect),
 /// [`subscribe`](Self::subscribe), [`unsubscribe`](Self::unsubscribe), and
 /// [`publish`](Self::publish) for QoS 1/2 preserve local session state across cancellation.
 /// Cancelling [`connect`](Self::connect) drops the supplied transport and leaves the session
@@ -93,5 +96,28 @@ where
     /// pending release state.
     pub fn is_publish_quiescent(&self) -> bool {
         self.data.outbound.is_quiescent()
+    }
+
+    /// Return the local completion state of one previously accepted outbound operation.
+    pub fn status(&self, op: &Op) -> OpStatus {
+        if op.generation != self.data.generation() {
+            return OpStatus::Invalidated;
+        }
+
+        let pending = match op.kind {
+            super::OpKind::PublishAtLeastOnce
+            | super::OpKind::Subscribe
+            | super::OpKind::Unsubscribe => self.data.outbound.has_retained(op.packet_id),
+            super::OpKind::PublishExactlyOnce => {
+                self.data.outbound.has_retained(op.packet_id)
+                    || self.data.outbound.has_pending_release(op.packet_id)
+            }
+        };
+
+        if pending {
+            OpStatus::Pending
+        } else {
+            OpStatus::Complete
+        }
     }
 }

--- a/src/mqtt_client/session/operations.rs
+++ b/src/mqtt_client/session/operations.rs
@@ -1,7 +1,7 @@
 use embassy_time::Instant;
 use embedded_io_async::Error as _;
 
-use crate::packets::{DisconnectReq, Pub, Subscribe, Unsubscribe};
+use crate::packets::{DisconnectReq, PublishHeader, Subscribe, Unsubscribe};
 use crate::types::{Properties, TopicFilter};
 use crate::{Error, Property, ProtocolError, PubError, QoS, debug, info, warn};
 
@@ -47,21 +47,14 @@ where
         self.require_retained_slot()?;
 
         let packet_id = self.data.next_packet_id();
-        let (offset, len) = self
-            .data
-            .outbound
-            .encode_packet(&Subscribe {
-                packet_id,
-                dup: false,
-                properties: Properties::Slice(properties),
-                topics,
-            })
-            .map_err(Error::Protocol)?;
+        let (offset, len) = self.data.outbound.encode_packet(&Subscribe {
+            packet_id,
+            dup: false,
+            properties: Properties::Slice(properties),
+            topics,
+        })?;
         self.runtime.require_packet_size(len)?;
-        self.data
-            .outbound
-            .retain_packet(packet_id, offset, len)
-            .map_err(Error::Protocol)?;
+        self.data.outbound.retain_packet(packet_id, offset, len)?;
         debug!(
             "Enqueued SUBSCRIBE packet_id={} len={} tx_used={}",
             packet_id,
@@ -89,21 +82,14 @@ where
         self.require_retained_slot()?;
 
         let packet_id = self.data.next_packet_id();
-        let (offset, len) = self
-            .data
-            .outbound
-            .encode_packet(&Unsubscribe {
-                packet_id,
-                dup: false,
-                properties: Properties::Slice(properties),
-                topics,
-            })
-            .map_err(Error::Protocol)?;
+        let (offset, len) = self.data.outbound.encode_packet(&Unsubscribe {
+            packet_id,
+            dup: false,
+            properties: Properties::Slice(properties),
+            topics,
+        })?;
         self.runtime.require_packet_size(len)?;
-        self.data
-            .outbound
-            .retain_packet(packet_id, offset, len)
-            .map_err(Error::Protocol)?;
+        self.data.outbound.retain_packet(packet_id, offset, len)?;
         debug!(
             "Enqueued UNSUBSCRIBE packet_id={} len={} tx_used={}",
             packet_id,
@@ -129,40 +115,42 @@ where
         P: crate::publication::ToPayload,
     {
         if self.connection.is_none() {
-            return Err(PubError::Session(Error::Disconnected));
+            return Err(Error::Disconnected.into());
         }
-        self.flush_outbound().await.map_err(PubError::Session)?;
+        self.flush_outbound().await?;
 
-        let mut publish: Pub<'_, P> = publication.into();
-        if let Some(max_qos) = self.runtime.max_qos
-            && self.downgrade_qos
-            && publish.qos > max_qos
-        {
-            publish.qos = max_qos;
-        }
-
-        publish.packet_id = (publish.qos > QoS::AtMostOnce).then(|| self.data.next_packet_id());
-        publish.dup = false;
-
-        let packet_id = publish.packet_id;
-        let qos = publish.qos;
+        let crate::publication::Publication {
+            topic,
+            properties,
+            qos,
+            payload,
+            retain,
+        } = publication;
+        let qos = match self.runtime.max_qos {
+            Some(max_qos) if self.downgrade_qos && qos > max_qos => max_qos,
+            _ => qos,
+        };
+        let packet_id = (qos > QoS::AtMostOnce).then(|| self.data.next_packet_id());
+        let header = PublishHeader {
+            topic: crate::types::Utf8String(topic),
+            packet_id,
+            properties,
+            retain,
+            qos,
+            dup: false,
+        };
         if packet_id.is_some() {
-            self.require_retained_slot().map_err(PubError::Session)?;
+            self.require_retained_slot()?;
         }
 
         if !self.can_publish(qos) {
-            return Err(PubError::Session(Error::NotReady));
+            return Err(Error::NotReady.into());
         }
 
         if let Some(packet_id) = packet_id {
-            let (offset, len) = self.data.outbound.encode_publish(publish)?;
-            self.runtime
-                .require_packet_size(len)
-                .map_err(PubError::Session)?;
-            self.data
-                .outbound
-                .retain_packet(packet_id, offset, len)
-                .map_err(|err| PubError::Session(Error::Protocol(err)))?;
+            let (offset, len) = self.data.outbound.encode_publish(&header, payload)?;
+            self.runtime.require_packet_size(len)?;
+            self.data.outbound.retain_packet(packet_id, offset, len)?;
             self.runtime.send_quota = self.runtime.send_quota.saturating_sub(1);
             debug!(
                 "Enqueued PUBLISH packet_id={} qos={:?} len={} send_quota={}/{} tx_used={}",
@@ -173,46 +161,30 @@ where
                 self.runtime.max_send_quota,
                 self.data.outbound.used()
             );
-            self.flush_outbound().await.map_err(PubError::Session)?;
+            self.flush_outbound().await?;
             return Ok(());
         }
 
-        let packet =
-            crate::ser::MqttSerializer::pub_to_buffer(self.data.outbound.scratch_space(), publish)
-                .map_err(|err| match err {
-                    crate::ser::PubError::Encode(err) => {
-                        PubError::Session(Error::Protocol(err.into()))
-                    }
-                    crate::ser::PubError::Payload(err) => PubError::Payload(err),
-                })?;
-        self.runtime
-            .require_packet_size(packet.len())
-            .map_err(PubError::Session)?;
+        let packet = crate::ser::MqttSerializer::pub_to_buffer(
+            self.data.outbound.scratch_space(),
+            &header,
+            payload,
+        )?;
+        self.runtime.require_packet_size(packet.len())?;
         debug!("Sending QoS0 PUBLISH len={}", packet.len());
-        if let Err(err) = {
-            let connection = self
-                .connection
-                .as_mut()
-                .ok_or(PubError::Session(Error::Disconnected))?;
-            crate::mqtt_client::outbound::write_all(connection, packet).await
-        } {
+        let connection = self.connection.as_mut().ok_or(Error::Disconnected)?;
+        if let Err(err) = crate::mqtt_client::outbound::write_all(connection, packet).await {
             if matches!(err, Error::WriteZero) {
-                return Err(PubError::Session(err));
+                return Err(err.into());
             }
             warn!("QoS0 PUBLISH write failed");
             self.handle_disconnect();
-            return Err(PubError::Session(err));
+            return Err(err.into());
         }
-        if let Err(err) = {
-            let connection = self
-                .connection
-                .as_mut()
-                .ok_or(PubError::Session(Error::Disconnected))?;
-            connection.flush().await
-        } {
+        if let Err(err) = connection.flush().await {
             warn!("QoS0 PUBLISH flush failed: {:?}", err.kind());
             self.handle_disconnect();
-            return Err(PubError::Session(Error::Transport(err)));
+            return Err(Error::Transport(err).into());
         }
         self.runtime.note_outbound_activity(Instant::now());
 

--- a/src/mqtt_client/session/operations.rs
+++ b/src/mqtt_client/session/operations.rs
@@ -3,7 +3,7 @@ use embedded_io_async::Error as _;
 
 use crate::packets::{DisconnectReq, PublishHeader, Subscribe, Unsubscribe};
 use crate::types::{Properties, TopicFilter};
-use crate::{Error, Property, ProtocolError, PubError, QoS, debug, info, warn};
+use crate::{Error, Op, Property, ProtocolError, PubError, QoS, debug, info, warn};
 
 use super::super::outbound::write_packet;
 use super::{Io, Session};
@@ -31,12 +31,14 @@ where
     /// Call this after [`connect`](Self::connect). A resumed [`ConnectEvent::Reconnected`]
     /// already kept broker-side subscriptions.
     ///
+    /// Returns an operation handle that can be checked with [`Session::status`](Self::status).
+    ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
     pub async fn subscribe(
         &mut self,
         topics: &[TopicFilter<'_>],
         properties: &[Property<'_>],
-    ) -> Result<(), Error<IO::Error>> {
+    ) -> Result<Op, Error<IO::Error>> {
         if self.connection.is_none() {
             return Err(Error::Disconnected);
         }
@@ -61,17 +63,24 @@ where
             len,
             self.data.outbound.used()
         );
-        self.flush_outbound().await
+        self.flush_outbound().await?;
+        Ok(Op::new(
+            super::super::OpKind::Subscribe,
+            packet_id,
+            self.data.generation(),
+        ))
     }
 
     /// Send an `UNSUBSCRIBE`.
+    ///
+    /// Returns an operation handle that can be checked with [`Session::status`](Self::status).
     ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
     pub async fn unsubscribe(
         &mut self,
         topics: &[&str],
         properties: &[Property<'_>],
-    ) -> Result<(), Error<IO::Error>> {
+    ) -> Result<Op, Error<IO::Error>> {
         if self.connection.is_none() {
             return Err(Error::Disconnected);
         }
@@ -96,21 +105,29 @@ where
             len,
             self.data.outbound.used()
         );
-        self.flush_outbound().await
+        self.flush_outbound().await?;
+        Ok(Op::new(
+            super::super::OpKind::Unsubscribe,
+            packet_id,
+            self.data.generation(),
+        ))
     }
 
     /// Send a `PUBLISH`.
     ///
     /// QoS 1 and 2 retain the encoded packet in the session TX buffer until broker ack and are
     /// cancel-safe if the underlying transport I/O futures are cancel-safe.
+    /// They return `Some(Op)` so the caller can check completion with
+    /// [`Session::status`](Self::status).
     ///
     /// QoS 0 bypasses retained outbound state, encodes into temporary TX scratch space, and writes
     /// directly to the transport. It therefore does not consume replay/in-flight slots and only
-    /// needs enough currently free TX space for that one encode, but it is not cancel-safe.
+    /// needs enough currently free TX space for that one encode, but it is not cancel-safe and
+    /// returns `None`.
     pub async fn publish<P>(
         &mut self,
         publication: crate::publication::Publication<'_, P>,
-    ) -> Result<(), PubError<P::Error, IO::Error>>
+    ) -> Result<Option<Op>, PubError<P::Error, IO::Error>>
     where
         P: crate::publication::ToPayload,
     {
@@ -162,7 +179,12 @@ where
                 self.data.outbound.used()
             );
             self.flush_outbound().await?;
-            return Ok(());
+            let kind = if qos == QoS::ExactlyOnce {
+                super::super::OpKind::PublishExactlyOnce
+            } else {
+                super::super::OpKind::PublishAtLeastOnce
+            };
+            return Ok(Some(Op::new(kind, packet_id, self.data.generation())));
         }
 
         let packet = crate::ser::MqttSerializer::pub_to_buffer(
@@ -188,7 +210,7 @@ where
         }
         self.runtime.note_outbound_activity(Instant::now());
 
-        Ok(())
+        Ok(None)
     }
 
     pub(super) fn require_retained_slot(&self) -> Result<(), Error<IO::Error>> {

--- a/src/mqtt_client/session/operations.rs
+++ b/src/mqtt_client/session/operations.rs
@@ -3,7 +3,7 @@ use embedded_io_async::Error as _;
 
 use crate::packets::{DisconnectReq, PublishHeader, Subscribe, Unsubscribe};
 use crate::types::{Properties, TopicFilter};
-use crate::{Error, Op, Property, ProtocolError, PubError, QoS, debug, info, warn};
+use crate::{Error, Op, Property, PubError, QoS, ResourceError, debug, info, warn};
 
 use super::super::outbound::write_packet;
 use super::{Io, Session};
@@ -43,7 +43,7 @@ where
             return Err(Error::Disconnected);
         }
         if topics.is_empty() {
-            return Err(ProtocolError::NoTopic.into());
+            return Err(Error::InvalidRequest);
         }
         self.flush_outbound().await?;
         self.require_retained_slot()?;
@@ -85,7 +85,7 @@ where
             return Err(Error::Disconnected);
         }
         if topics.is_empty() {
-            return Err(ProtocolError::NoTopic.into());
+            return Err(Error::InvalidRequest);
         }
         self.flush_outbound().await?;
         self.require_retained_slot()?;
@@ -215,7 +215,7 @@ where
 
     pub(super) fn require_retained_slot(&self) -> Result<(), Error<IO::Error>> {
         if self.data.outbound.retained_full() {
-            return Err(ProtocolError::InflightMetadataExhausted.into());
+            return Err(Error::Resource(ResourceError::InflightExhausted));
         }
         Ok(())
     }

--- a/src/mqtt_client/session/state.rs
+++ b/src/mqtt_client/session/state.rs
@@ -3,7 +3,7 @@ use core::num::NonZeroU16;
 use embassy_time::{Duration, Instant};
 use heapless::Vec;
 
-use crate::{Error, ProtocolError, QoS, ReasonCode};
+use crate::{Error, QoS, ResourceError};
 
 use super::super::outbound::Outbound;
 
@@ -58,9 +58,7 @@ impl RuntimeState {
             .maximum_packet_size
             .is_some_and(|max| len > max as usize)
         {
-            return Err(Error::Protocol(ProtocolError::Failed(
-                ReasonCode::PacketTooLarge,
-            )));
+            return Err(Error::Resource(ResourceError::PacketTooLarge));
         }
         Ok(())
     }

--- a/src/mqtt_client/session/state.rs
+++ b/src/mqtt_client/session/state.rs
@@ -7,7 +7,12 @@ use crate::{Error, ProtocolError, QoS, ReasonCode};
 
 use super::super::outbound::Outbound;
 
-pub(super) const PING_TIMEOUT_MS: u64 = 5_000;
+/// Upper bound for one MQTT keepalive round trip.
+///
+/// This single constant drives both:
+/// - how early `minimq` sends a `PINGREQ` before keepalive expiry
+/// - how long it waits for the matching `PINGRESP`
+pub(super) const ROUND_TRIP_TIMEOUT_MS: u64 = 5_000;
 const MAX_INBOUND_QOS2: usize = 8;
 
 #[derive(Debug)]
@@ -66,7 +71,7 @@ impl RuntimeState {
             return None;
         }
 
-        let lead_ms = PING_TIMEOUT_MS.min(keepalive_ms / 2);
+        let lead_ms = ROUND_TRIP_TIMEOUT_MS.min(keepalive_ms / 2);
         Some(Duration::from_millis(keepalive_ms - lead_ms))
     }
 
@@ -83,6 +88,7 @@ impl RuntimeState {
 #[derive(Debug)]
 pub(super) struct SessionData<'a> {
     packet_id: NonZeroU16,
+    generation: u32,
     pub(super) outbound: Outbound<'a>,
     pub(super) pending_server_packet_ids: Vec<u16, MAX_INBOUND_QOS2>,
     pub(super) session_present: bool,
@@ -92,6 +98,7 @@ impl<'a> SessionData<'a> {
     pub(super) fn new(outbound: &'a mut [u8]) -> Self {
         Self {
             packet_id: NonZeroU16::new(1).unwrap(),
+            generation: 0,
             outbound: Outbound::new(outbound),
             pending_server_packet_ids: Vec::new(),
             session_present: false,
@@ -104,9 +111,14 @@ impl<'a> SessionData<'a> {
 
     pub(super) fn reset(&mut self) {
         self.session_present = false;
+        self.generation = self.generation.wrapping_add(1);
         self.packet_id = NonZeroU16::new(1).unwrap();
         self.outbound.clear();
         self.pending_server_packet_ids.clear();
+    }
+
+    pub(super) fn generation(&self) -> u32 {
+        self.generation
     }
 
     pub(super) fn next_packet_id(&mut self) -> u16 {

--- a/src/mqtt_client/session/tests.rs
+++ b/src/mqtt_client/session/tests.rs
@@ -1,4 +1,4 @@
-use super::state::PING_TIMEOUT_MS;
+use super::state::ROUND_TRIP_TIMEOUT_MS;
 use crate::ser::MAX_FIXED_HEADER_SIZE;
 use crate::{Buffers, ConfigBuilder, Publication, tests::block_on};
 use crate::{ConnectEvent, Error, ProtocolError, Session};
@@ -82,7 +82,7 @@ fn maintain_sends_pingreq_when_due() {
     );
     assert_eq!(
         session.runtime.ping_timeout,
-        Some(now + Duration::from_millis(PING_TIMEOUT_MS))
+        Some(now + Duration::from_millis(ROUND_TRIP_TIMEOUT_MS))
     );
     assert_eq!(
         session.runtime.next_ping,
@@ -154,6 +154,26 @@ fn drive_returns_none_when_waiting_for_read() {
 }
 
 #[test]
+fn poll_returns_none_after_internal_progress() {
+    let mut session = session();
+    session.connection = Some(MockConnection::default());
+    session.runtime.next_ping = Some(Instant::now());
+
+    let result = block_on(session.poll()).unwrap();
+
+    assert!(result.is_none());
+    assert!(
+        session
+            .connection
+            .as_ref()
+            .unwrap()
+            .tx
+            .iter()
+            .any(|frame| frame.as_slice() == [0xC0, 0x00])
+    );
+}
+
+#[test]
 fn inbound_publish_does_not_refresh_keepalive_deadline() {
     let mut session = session();
     session.connection = Some(MockConnection::default());
@@ -166,7 +186,9 @@ fn inbound_publish_does_not_refresh_keepalive_deadline() {
         .unwrap()
         .push_rx(&[0x30, 0x05, 0x00, 0x01, b'A', 0x00, 0x05]);
 
-    let result = block_on(session.poll()).unwrap();
+    let result = block_on(session.poll())
+        .unwrap()
+        .expect("expected inbound publish");
     assert_eq!(result.topic(), "A", "{result:?}");
     assert_eq!(session.runtime.next_ping, Some(deadline));
 }

--- a/src/mqtt_client/session/tests.rs
+++ b/src/mqtt_client/session/tests.rs
@@ -1,7 +1,7 @@
 use super::state::ROUND_TRIP_TIMEOUT_MS;
 use crate::ser::MAX_FIXED_HEADER_SIZE;
 use crate::{Buffers, ConfigBuilder, Publication, tests::block_on};
-use crate::{ConnectEvent, Error, ProtocolError, Session};
+use crate::{ConnectEvent, Error, ResourceError, Session};
 use embassy_time::{Duration, Instant};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use std::collections::VecDeque;
@@ -277,9 +277,7 @@ fn connect_returns_insufficient_memory_when_tx_is_too_small() {
 
     assert!(matches!(
         result,
-        Err(Error::Protocol(ProtocolError::Encode(
-            crate::SerError::InsufficientMemory
-        )))
+        Err(Error::Resource(ResourceError::BufferTooSmall))
     ));
 }
 

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1,6 +1,5 @@
 use crate::{
     QoS, Retain,
-    publication::Publication,
     reason_codes::ReasonCode,
     types::{Auth, BinaryData, Properties, TopicFilter, Utf8String},
     will::Will,
@@ -67,18 +66,26 @@ pub struct ConnAck<'a> {
     pub properties: Properties<'a>,
 }
 
-#[derive(Serialize)]
-pub struct Pub<'a, P> {
+#[derive(Debug, Serialize)]
+pub struct PublishHeader<'a> {
     pub topic: Utf8String<'a>,
     pub packet_id: Option<u16>,
     pub properties: Properties<'a>,
-    #[serde(skip)]
-    pub payload: P,
     #[serde(skip)]
     pub retain: Retain,
     #[serde(skip)]
     pub qos: QoS,
     #[serde(skip)]
+    pub dup: bool,
+}
+
+pub struct Pub<'a, P> {
+    pub topic: Utf8String<'a>,
+    pub packet_id: Option<u16>,
+    pub properties: Properties<'a>,
+    pub payload: P,
+    pub retain: Retain,
+    pub qos: QoS,
     pub dup: bool,
 }
 
@@ -93,20 +100,6 @@ impl<P> core::fmt::Debug for Pub<'_, P> {
             .field("dup", &self.dup)
             .field("payload", &"<deferred>")
             .finish()
-    }
-}
-
-impl<'a, P> From<Publication<'a, P>> for Pub<'a, P> {
-    fn from(publication: Publication<'a, P>) -> Self {
-        Self {
-            topic: Utf8String(publication.topic),
-            properties: publication.properties,
-            packet_id: None,
-            payload: publication.payload,
-            retain: publication.retain,
-            qos: publication.qos,
-            dup: false,
-        }
     }
 }
 
@@ -296,18 +289,18 @@ mod tests {
             0xAB, 0xCD, // Payload
         ];
 
-        let publish = crate::packets::Pub {
+        let header = crate::packets::PublishHeader {
             qos: crate::QoS::AtMostOnce,
             packet_id: None,
             dup: false,
             properties: crate::types::Properties::Slice(&[]),
             retain: crate::Retain::NotRetained,
             topic: crate::types::Utf8String("ABC"),
-            payload: &[0xAB, 0xCD][..],
         };
+        let payload = &[0xAB, 0xCD][..];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::pub_to_buffer(&mut buffer, publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &header, payload).unwrap();
 
         assert_eq!(message, good_publish);
     }
@@ -323,18 +316,18 @@ mod tests {
             0xAB, 0xCD, // Payload
         ];
 
-        let publish = crate::packets::Pub {
+        let header = crate::packets::PublishHeader {
             qos: crate::QoS::AtLeastOnce,
             topic: crate::types::Utf8String("ABC"),
             packet_id: Some(0xBEEF),
             dup: false,
             properties: crate::types::Properties::Slice(&[]),
             retain: crate::Retain::NotRetained,
-            payload: &[0xAB, 0xCD][..],
         };
+        let payload = &[0xAB, 0xCD][..];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::pub_to_buffer(&mut buffer, publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &header, payload).unwrap();
 
         assert_eq!(message, good_publish);
     }
@@ -397,7 +390,7 @@ mod tests {
             0xAB, 0xCD, // Payload
         ];
 
-        let publish = crate::packets::Pub {
+        let header = crate::packets::PublishHeader {
             qos: crate::QoS::AtMostOnce,
             topic: crate::types::Utf8String("ABC"),
             packet_id: None,
@@ -406,11 +399,11 @@ mod tests {
                 crate::properties::Property::ResponseTopic(crate::types::Utf8String("A")),
             ]),
             retain: crate::Retain::NotRetained,
-            payload: &[0xAB, 0xCD][..],
         };
+        let payload = &[0xAB, 0xCD][..];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::pub_to_buffer(&mut buffer, publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &header, payload).unwrap();
 
         assert_eq!(message, good_publish);
     }
@@ -426,7 +419,7 @@ mod tests {
             0xAB, 0xCD, // Payload
         ];
 
-        let publish = crate::packets::Pub {
+        let header = crate::packets::PublishHeader {
             qos: crate::QoS::AtMostOnce,
             topic: crate::types::Utf8String("ABC"),
             packet_id: None,
@@ -438,11 +431,11 @@ mod tests {
                 ),
             ]),
             retain: crate::Retain::NotRetained,
-            payload: &[0xAB, 0xCD][..],
         };
+        let payload = &[0xAB, 0xCD][..];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let message = MqttSerializer::pub_to_buffer(&mut buffer, publish).unwrap();
+        let message = MqttSerializer::pub_to_buffer(&mut buffer, &header, payload).unwrap();
 
         assert_eq!(message, good_publish);
     }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -496,7 +496,7 @@ mod tests {
         ];
 
         let mut buffer: [u8; 900] = [0; 900];
-        let will = crate::will::Will::new("EFG", &[0xAB, 0xCD], &[])
+        let will = crate::will::Will::new("EFG".try_into().unwrap(), &[0xAB, 0xCD], &[])
             .unwrap()
             .qos(crate::QoS::AtMostOnce);
 

--- a/src/publication.rs
+++ b/src/publication.rs
@@ -1,6 +1,6 @@
 use crate::properties::Property;
 use crate::types::Properties;
-use crate::{ProtocolError, QoS, Retain};
+use crate::{QoS, ResourceError, Retain};
 use heapless::{String, Vec};
 
 /// Trait for values that can serialize themselves into a publish payload buffer.
@@ -30,17 +30,17 @@ impl<'a> ResponseTarget<'a> {
 
     pub(crate) fn to_owned<const TOPIC: usize, const CORRELATION: usize>(
         self,
-    ) -> Result<OwnedResponseTarget<TOPIC, CORRELATION>, ProtocolError> {
+    ) -> Result<OwnedResponseTarget<TOPIC, CORRELATION>, ResourceError> {
         Ok(OwnedResponseTarget {
             topic: self
                 .topic
                 .try_into()
-                .map_err(|_| ProtocolError::BufferSize)?,
+                .map_err(|_| ResourceError::BufferTooSmall)?,
             correlation_data: self
                 .correlation_data
                 .map(Vec::try_from)
                 .transpose()
-                .map_err(|_| ProtocolError::BufferSize)?,
+                .map_err(|_| ResourceError::BufferTooSmall)?,
         })
     }
 }

--- a/src/publication.rs
+++ b/src/publication.rs
@@ -32,7 +32,10 @@ impl<'a> ResponseTarget<'a> {
         self,
     ) -> Result<OwnedResponseTarget<TOPIC, CORRELATION>, ProtocolError> {
         Ok(OwnedResponseTarget {
-            topic: String::try_from(self.topic).map_err(|_| ProtocolError::BufferSize)?,
+            topic: self
+                .topic
+                .try_into()
+                .map_err(|_| ProtocolError::BufferSize)?,
             correlation_data: self
                 .correlation_data
                 .map(Vec::try_from)

--- a/src/reason_codes.rs
+++ b/src/reason_codes.rs
@@ -1,8 +1,8 @@
-use crate::ProtocolError;
+use crate::PeerError;
 use num_enum::{FromPrimitive, IntoPrimitive};
 
 /// MQTTv5-defined codes that may be returned in response to control packets.
-#[derive(PartialEq, PartialOrd, Copy, Clone, Debug, FromPrimitive, IntoPrimitive)]
+#[derive(PartialEq, Eq, PartialOrd, Copy, Clone, Debug, FromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum ReasonCode {
     /// Success.
@@ -127,12 +127,12 @@ impl From<&ReasonCode> for u8 {
 }
 
 impl ReasonCode {
-    /// Convert the reason code to `Ok(())` for success codes or a protocol error otherwise.
-    pub fn as_result(&self) -> Result<(), ProtocolError> {
+    /// Convert the reason code to `Ok(())` for success codes or a peer rejection otherwise.
+    pub fn as_result(&self) -> Result<(), PeerError> {
         if self.success() {
             return Ok(());
         }
-        Err(ProtocolError::Failed(*self))
+        Err(PeerError::Rejected(*self))
     }
 
     /// Return `true` for MQTT success codes.

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -29,7 +29,7 @@
 use crate::varint::VarintBuffer;
 use crate::{
     message_types::{ControlPacket, MessageType},
-    packets::Pub,
+    packets::PublishHeader,
 };
 use bit_field::BitField;
 use serde::Serialize;
@@ -132,17 +132,17 @@ impl<'a> MqttSerializer<'a> {
 
     pub fn pub_to_buffer_meta<P: crate::publication::ToPayload>(
         buf: &'a mut [u8],
-        pub_packet: Pub<'_, P>,
+        header: &PublishHeader<'_>,
+        payload: P,
     ) -> Result<(usize, &'a [u8]), PubError<P::Error>> {
         let mut serializer = crate::ser::MqttSerializer::new(buf);
-        pub_packet
+        header
             .serialize(&mut serializer)
             .map_err(PubError::Encode)?;
 
         // Next, serialize the payload into the remaining buffer
-        let flags = pub_packet.fixed_header_flags();
-        let len = pub_packet
-            .payload
+        let flags = header.fixed_header_flags();
+        let len = payload
             .serialize(serializer.remainder())
             .map_err(PubError::Payload)?;
         serializer.commit(len).map_err(PubError::Encode)?;
@@ -156,9 +156,10 @@ impl<'a> MqttSerializer<'a> {
 
     pub fn pub_to_buffer<P: crate::publication::ToPayload>(
         buf: &'a mut [u8],
-        pub_packet: Pub<'_, P>,
+        header: &PublishHeader<'_>,
+        payload: P,
     ) -> Result<&'a [u8], PubError<P::Error>> {
-        let (_, packet) = Self::pub_to_buffer_meta(buf, pub_packet)?;
+        let (_, packet) = Self::pub_to_buffer_meta(buf, header, payload)?;
         Ok(packet)
     }
 
@@ -532,7 +533,11 @@ impl serde::ser::SerializeStructVariant for &mut MqttSerializer<'_> {
 #[cfg(test)]
 mod tests {
     use super::{Error, MqttSerializer};
-    use crate::{packets::PingReq, publication::Publication};
+    use crate::{
+        packets::{PingReq, PublishHeader},
+        publication::Publication,
+        types::Utf8String,
+    };
 
     #[test]
     fn control_packet_encode_rejects_buffers_smaller_than_fixed_header() {
@@ -547,8 +552,16 @@ mod tests {
     fn publish_encode_rejects_buffers_smaller_than_fixed_header() {
         for len in 0..super::MAX_FIXED_HEADER_SIZE {
             let mut buf = vec![0u8; len];
-            let publish = crate::packets::Pub::from(Publication::bytes("a", b"x"));
-            let result = MqttSerializer::pub_to_buffer(&mut buf, publish);
+            let publication = Publication::bytes("a", b"x");
+            let header = PublishHeader {
+                topic: Utf8String(publication.topic),
+                packet_id: None,
+                properties: publication.properties,
+                retain: publication.retain,
+                qos: publication.qos,
+                dup: false,
+            };
+            let result = MqttSerializer::pub_to_buffer(&mut buf, &header, publication.payload);
             assert!(matches!(
                 result,
                 Err(crate::ser::PubError::Encode(Error::InsufficientMemory))

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! MQTT-specific data types used by the public API.
 use crate::{
-    ProtocolError, QoS, de::deserializer::MqttDeserializer, properties::Property, varint::Varint,
+    PeerError, QoS, de::deserializer::MqttDeserializer, properties::Property, varint::Varint,
 };
 use bit_field::BitField;
 use serde::ser::SerializeStruct;
@@ -127,7 +127,7 @@ impl<'a> PropertiesIter<'a> {
 }
 
 impl<'a> core::iter::Iterator for PropertiesIter<'a> {
-    type Item = Result<Property<'a>, ProtocolError>;
+    type Item = Result<Property<'a>, PeerError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.inner {
@@ -137,8 +137,8 @@ impl<'a> core::iter::Iterator for PropertiesIter<'a> {
                 }
 
                 let mut deserializer = MqttDeserializer::new(&props[*index..]);
-                let property = Property::deserialize(&mut deserializer)
-                    .map_err(ProtocolError::Deserialization);
+                let property =
+                    Property::deserialize(&mut deserializer).map_err(|_| PeerError::InvalidPacket);
                 *index += deserializer.deserialized_bytes();
                 Some(property)
             }
@@ -167,7 +167,7 @@ impl<'a> core::iter::Iterator for PropertiesIter<'a> {
 }
 
 impl<'a> core::iter::IntoIterator for &'a Properties<'a> {
-    type Item = Result<Property<'a>, ProtocolError>;
+    type Item = Result<Property<'a>, PeerError>;
     type IntoIter = PropertiesIter<'a>;
 
     fn into_iter(self) -> PropertiesIter<'a> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -317,14 +317,14 @@ impl<'de> serde::de::Deserialize<'de> for BinaryData<'de> {
 
 /// Username/password authentication data used in `CONNECT`.
 #[derive(Debug, Copy, Clone)]
-pub struct Auth<'a> {
+pub(crate) struct Auth<'a> {
     user_name: &'a str,
     password: &'a [u8],
 }
 
 impl<'a> Auth<'a> {
     /// Construct MQTT username/password authentication data.
-    pub const fn new(user_name: &'a str, password: &'a [u8]) -> Self {
+    pub(crate) const fn new(user_name: &'a str, password: &'a [u8]) -> Self {
         Self {
             user_name,
             password,
@@ -332,12 +332,12 @@ impl<'a> Auth<'a> {
     }
 
     /// Return the MQTT username.
-    pub const fn user_name(&self) -> &'a str {
+    pub(crate) const fn user_name(&self) -> &'a str {
         self.user_name
     }
 
     /// Return the MQTT password bytes.
-    pub const fn password(&self) -> &'a [u8] {
+    pub(crate) const fn password(&self) -> &'a [u8] {
         self.password
     }
 }

--- a/src/will.rs
+++ b/src/will.rs
@@ -1,10 +1,10 @@
 use crate::{
-    ProtocolError, QoS, Retain, TopicString,
+    ConfigError, QoS, Retain, TopicString,
     properties::{Property, PropertyIdentifier},
     types::{BinaryData, Properties, Utf8String},
 };
 
-fn validate_will_properties(properties: &[Property<'_>]) -> Result<(), ProtocolError> {
+fn validate_will_properties(properties: &[Property<'_>]) -> Result<(), ConfigError> {
     for property in properties {
         match property.into() {
             PropertyIdentifier::WillDelayInterval
@@ -14,7 +14,7 @@ fn validate_will_properties(properties: &[Property<'_>]) -> Result<(), ProtocolE
             | PropertyIdentifier::ResponseTopic
             | PropertyIdentifier::CorrelationData
             | PropertyIdentifier::UserProperty => {}
-            _ => return Err(ProtocolError::InvalidProperty),
+            _ => return Err(ConfigError::InvalidConfig),
         }
     }
     Ok(())
@@ -38,7 +38,7 @@ impl<'a> Will<'a> {
         topic: TopicString,
         data: &'a [u8],
         properties: &'a [Property<'a>],
-    ) -> Result<Self, ProtocolError> {
+    ) -> Result<Self, ConfigError> {
         validate_will_properties(properties)?;
 
         Ok(Self {

--- a/src/will.rs
+++ b/src/will.rs
@@ -1,9 +1,8 @@
 use crate::{
-    ProtocolError, QoS, Retain,
+    ProtocolError, QoS, Retain, TopicString,
     properties::{Property, PropertyIdentifier},
     types::{BinaryData, Properties, Utf8String},
 };
-use heapless::String;
 
 fn validate_will_properties(properties: &[Property<'_>]) -> Result<(), ProtocolError> {
     for property in properties {
@@ -21,25 +20,10 @@ fn validate_will_properties(properties: &[Property<'_>]) -> Result<(), ProtocolE
     Ok(())
 }
 
-#[derive(Debug, Clone, PartialEq)]
-enum Topic<'a> {
-    Borrowed(&'a str),
-    Owned(String<128>),
-}
-
-impl Topic<'_> {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Borrowed(topic) => topic,
-            Self::Owned(topic) => topic.as_str(),
-        }
-    }
-}
-
 /// MQTT will message.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Will<'a> {
-    topic: Topic<'a>,
+    topic: TopicString,
     data: &'a [u8],
     qos: QoS,
     retained: Retain,
@@ -47,34 +31,18 @@ pub struct Will<'a> {
 }
 
 impl<'a> Will<'a> {
-    /// Construct a will that borrows its topic.
+    /// Construct a will from owned fixed-capacity topic storage.
     ///
     /// Only MQTT v5 properties valid on will messages are accepted.
     pub fn new(
-        topic: &'a str,
+        topic: TopicString,
         data: &'a [u8],
         properties: &'a [Property<'a>],
     ) -> Result<Self, ProtocolError> {
         validate_will_properties(properties)?;
 
         Ok(Self {
-            topic: Topic::Borrowed(topic),
-            data,
-            properties,
-            qos: QoS::AtMostOnce,
-            retained: Retain::NotRetained,
-        })
-    }
-
-    /// Construct a will that owns its fixed-capacity topic.
-    pub fn owned(
-        topic: &str,
-        data: &'a [u8],
-        properties: &'a [Property<'a>],
-    ) -> Result<Self, ProtocolError> {
-        validate_will_properties(properties)?;
-        Ok(Self {
-            topic: Topic::Owned(String::try_from(topic).map_err(|_| ProtocolError::BufferSize)?),
+            topic,
             data,
             properties,
             qos: QoS::AtMostOnce,

--- a/tests/async_client.rs
+++ b/tests/async_client.rs
@@ -3,7 +3,7 @@ mod support;
 use embassy_time::{Duration, with_timeout};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use minimq::{
-    Buffers, ConfigBuilder, ConnectEvent, Error, InboundPublish, PeerError, Property, PubError,
+    Buffers, ConfigBuilder, ConnectEvent, Error, InboundPublish, Op, PeerError, Property, PubError,
     Publication, QoS, ReasonCode, ResourceError, Session,
     types::{BinaryData, Properties, TopicFilter},
 };
@@ -334,10 +334,14 @@ fn outbound_pubcomp(id: u16, reason: u8) -> [u8; 5] {
 }
 
 fn connected_session(connector: &MockConnector) -> Session<'static, MockConnection> {
-    let mut session = Session::new(config());
+    let mut session = session();
     expect_connected(&mut session, connector);
     assert!(session.is_connected());
     session
+}
+
+fn session() -> Session<'static, MockConnection> {
+    Session::new(config())
 }
 
 fn expect_connected(session: &mut Session<'static, MockConnection>, connector: &MockConnector) {
@@ -429,7 +433,7 @@ fn wait_for_tx_frame(
 fn fill_inflight_publish_slots(session: &mut Session<'static, MockConnection>) -> usize {
     let mut count = 0;
     loop {
-        match block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))) {
+        match publish_qos1(session, "data", b"x") {
             Ok(Some(_)) => count += 1,
             Ok(None) => unreachable!("QoS1 publish must return an op handle"),
             Err(PubError::Session(Error::Resource(ResourceError::InflightExhausted))) => {
@@ -440,12 +444,36 @@ fn fill_inflight_publish_slots(session: &mut Session<'static, MockConnection>) -
     }
 }
 
+fn publish_qos1(
+    session: &mut Session<'static, MockConnection>,
+    topic: &str,
+    payload: &[u8],
+) -> Result<Option<Op>, PubError<(), ErrorKind>> {
+    block_on(session.publish(Publication::bytes(topic, payload).qos(QoS::AtLeastOnce)))
+}
+
+fn publish_qos1_ok(session: &mut Session<'static, MockConnection>, topic: &str, payload: &[u8]) {
+    publish_qos1(session, topic, payload).unwrap();
+}
+
+fn publish_qos2(
+    session: &mut Session<'static, MockConnection>,
+    topic: &str,
+    payload: &[u8],
+) -> Result<Option<Op>, PubError<(), ErrorKind>> {
+    block_on(session.publish(Publication::bytes(topic, payload).qos(QoS::ExactlyOnce)))
+}
+
+fn publish_qos2_ok(session: &mut Session<'static, MockConnection>, topic: &str, payload: &[u8]) {
+    publish_qos2(session, topic, payload).unwrap();
+}
+
 #[test]
 fn fragmented_connack_still_establishes_session() {
     let mut connection = MockConnection::default();
     connection.push_rx_fragmented(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     assert!(session.is_connected());
@@ -473,18 +501,16 @@ fn publish_requires_connected_session() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = Session::new(config());
+    let mut session = session();
 
-    let result =
-        block_on(session.publish(Publication::bytes("data", b"payload").qos(QoS::AtLeastOnce)));
+    let result = publish_qos1(&mut session, "data", b"payload");
     assert!(matches!(
         result,
         Err(PubError::Session(Error::Disconnected))
     ));
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"payload").qos(QoS::AtLeastOnce)))
-        .unwrap();
+    publish_qos1_ok(&mut session, "data", b"payload");
 }
 
 #[test]
@@ -504,7 +530,7 @@ fn publish_survives_cancellation_during_pending_write() {
 
     assert_eq!(inspect.tx().len(), 1);
     assert!(poll_now(&mut session).unwrap().is_none());
-    block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"y");
 }
 
 #[test]
@@ -522,10 +548,10 @@ fn cancelled_publish_still_holds_receive_max_quota() {
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
-    let result = block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::AtLeastOnce)));
+    let result = publish_qos1(&mut session, "data", b"y");
     assert!(matches!(result, Err(PubError::Session(Error::NotReady))));
     for _ in 0..WAIT_STEPS {
-        match block_on(session.publish(Publication::bytes("data", b"z").qos(QoS::AtLeastOnce))) {
+        match publish_qos1(&mut session, "data", b"z") {
             Ok(Some(_)) => return,
             Ok(None) => unreachable!("QoS1 publish must return an op handle"),
             Err(PubError::Session(Error::NotReady)) => {
@@ -584,7 +610,7 @@ fn qos2_pubrel_survives_cancellation_during_pending_write() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::ExactlyOnce))).unwrap();
+    publish_qos2_ok(&mut session, "data", b"x");
     assert!(poll_now(&mut session).unwrap().is_none());
 
     inspect.pend_writes(1);
@@ -617,7 +643,7 @@ fn inflight_packets_are_not_replayed_during_normal_poll() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
     let tx_after_publish = connector.connections.borrow().front().is_none();
     assert!(tx_after_publish);
 
@@ -636,10 +662,10 @@ fn broker_disconnect_marks_inflight_for_replay_on_resume() {
         second
     };
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
     expect_disconnected(&mut session);
     expect_reconnected(&mut session, &connector);
 }
@@ -654,7 +680,7 @@ fn broker_disconnect_without_session_resume_reports_connected() {
     second.push_rx(&connack());
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     expect_disconnected(&mut session);
@@ -668,7 +694,7 @@ fn failed_connack_disconnects_session_and_allows_reconnect() {
     let mut second = MockConnection::default();
     second.push_rx(&connack());
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
@@ -685,7 +711,7 @@ fn broker_disconnect_during_connect_disconnects_session_and_allows_reconnect() {
     let mut second = MockConnection::default();
     second.push_rx(&connack());
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
@@ -702,7 +728,7 @@ fn zero_receive_maximum_disconnects_session_and_allows_reconnect() {
     let mut second = MockConnection::default();
     second.push_rx(&connack());
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
@@ -719,7 +745,7 @@ fn oversized_assigned_client_id_disconnects_session_and_allows_reconnect() {
     let mut second = MockConnection::default();
     second.push_rx(&connack());
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
@@ -736,7 +762,7 @@ fn timed_out_connack_disconnects_session_and_allows_reconnect() {
     let mut second = MockConnection::default();
     second.push_rx(&connack());
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
@@ -755,7 +781,7 @@ fn malformed_inbound_packet_disconnects_session_and_allows_reconnect() {
     let mut second = MockConnection::default();
     second.push_rx(&connack());
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     expect_poll_error(&mut session, |err| {
@@ -787,7 +813,7 @@ fn outbound_qos_acks_can_arrive_out_of_order() {
     let mut session = connected_session(&connector);
 
     for _ in 0..3 {
-        block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+        publish_qos1_ok(&mut session, "data", b"x");
     }
     assert!(poll_now(&mut session).unwrap().is_none());
     assert!(poll_now(&mut session).unwrap().is_none());
@@ -806,7 +832,7 @@ fn subscribe_is_replayed_after_disconnect_until_suback() {
     second.push_rx(&suback(1, 0x01));
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     block_on(session.subscribe(&[TopicFilter::new("data")], &[])).unwrap();
@@ -853,8 +879,10 @@ fn subscribe_rejects_empty_topic_list() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    let result = block_on(session.subscribe(&[], &[]));
-    assert!(matches!(result, Err(Error::InvalidRequest)));
+    assert!(matches!(
+        block_on(session.subscribe(&[], &[])),
+        Err(Error::InvalidRequest)
+    ));
 }
 
 #[test]
@@ -864,8 +892,10 @@ fn unsubscribe_rejects_empty_topic_list() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    let result = block_on(session.unsubscribe(&[], &[]));
-    assert!(matches!(result, Err(Error::InvalidRequest)));
+    assert!(matches!(
+        block_on(session.unsubscribe(&[], &[])),
+        Err(Error::InvalidRequest)
+    ));
 }
 
 #[test]
@@ -880,7 +910,7 @@ fn outbound_qos2_flow_allows_out_of_order_pubrec_and_pubcomp() {
     let mut session = connected_session(&connector);
 
     for _ in 0..2 {
-        block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::ExactlyOnce))).unwrap();
+        publish_qos2_ok(&mut session, "data", b"x");
     }
 
     for _ in 0..4 {
@@ -918,7 +948,7 @@ fn resumed_session_suppresses_duplicate_inbound_qos2_publish() {
     second.push_rx(&pubrel(9));
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     with_inbound(&mut session, |message| assert_eq!(message.topic(), "data"));
@@ -953,7 +983,7 @@ fn fresh_session_clears_pending_inbound_qos2_state() {
     second.push_rx(&pubrel(9));
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     with_inbound(&mut session, |message| assert_eq!(message.topic(), "data"));
@@ -1011,10 +1041,10 @@ fn connack_receive_maximum_clamps_local_quota() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
+    publish_qos1_ok(&mut session, "data", b"x");
 
-    let result = block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce)));
+    let result = publish_qos1(&mut session, "data", b"x");
     assert!(matches!(result, Err(PubError::Session(Error::NotReady))));
 }
 
@@ -1033,7 +1063,7 @@ fn session_allows_publish_after_message_borrow_is_dropped() {
         });
     }
 
-    block_on(session.publish(Publication::bytes("reply", b"ok").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "reply", b"ok");
 }
 
 #[test]
@@ -1046,18 +1076,17 @@ fn session_reconnects_after_write_error() {
     second.push_rx(&connack_session_present());
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    let error = block_on(session.publish(Publication::bytes("reply", b"ok").qos(QoS::AtLeastOnce)))
-        .unwrap_err();
+    let error = publish_qos1(&mut session, "reply", b"ok").unwrap_err();
     assert!(matches!(
         error,
         PubError::Session(Error::Transport(ErrorKind::ConnectionReset))
     ));
 
     expect_reconnected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("reply", b"ok").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "reply", b"ok");
 }
 
 #[test]
@@ -1068,14 +1097,14 @@ fn puback_failure_is_reported_and_clears_inflight() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
             Error::Peer(PeerError::Rejected(ReasonCode::NotAuthorized))
         )
     });
-    block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"y");
 }
 
 #[test]
@@ -1086,14 +1115,14 @@ fn pubrec_failure_is_reported_and_clears_inflight() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::ExactlyOnce))).unwrap();
+    publish_qos2_ok(&mut session, "data", b"x");
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
             Error::Peer(PeerError::Rejected(ReasonCode::QuotaExceeded))
         )
     });
-    block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::ExactlyOnce))).unwrap();
+    publish_qos2_ok(&mut session, "data", b"y");
 }
 
 #[test]
@@ -1105,14 +1134,14 @@ fn pubcomp_failure_is_reported_and_clears_release_state() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::ExactlyOnce))).unwrap();
+    publish_qos2_ok(&mut session, "data", b"x");
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
             Error::Peer(PeerError::Rejected(ReasonCode::ImplementationError))
         )
     });
-    block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::ExactlyOnce))).unwrap();
+    publish_qos2_ok(&mut session, "data", b"y");
 }
 
 #[test]
@@ -1120,7 +1149,7 @@ fn poll_requires_connected_session() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     assert!(matches!(block_on(session.poll()), Err(Error::Disconnected)));
     expect_connected(&mut session, &connector);
@@ -1137,7 +1166,7 @@ fn connect_retries_cleanly_after_cancellation_during_pending_write() {
         connection
     };
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     let mut future = Box::pin(session.connect(connector.connect().unwrap()));
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
@@ -1159,7 +1188,7 @@ fn connect_retries_cleanly_after_cancellation_during_pending_connack() {
         connection
     };
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     let mut future = Box::pin(session.connect(connector.connect().unwrap()));
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
@@ -1217,10 +1246,10 @@ fn session_reconnects_after_replay_write_error() {
     third.push_rx(&connack_session_present());
 
     let connector = MockConnector::with_connections([first, second, third]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
 
     expect_disconnected(&mut session);
     expect_reconnected(&mut session, &connector);
@@ -1248,10 +1277,10 @@ fn qos1_publish_replays_across_multiple_resumed_reconnects() {
     third.push_rx(&puback(1));
 
     let connector = MockConnector::with_connections([first, second, third]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
 
     expect_disconnected(&mut session);
     expect_reconnected(&mut session, &connector);
@@ -1291,10 +1320,10 @@ fn qos2_pubrel_replays_across_multiple_resumed_reconnects() {
     third.push_rx(&pubcomp(1));
 
     let connector = MockConnector::with_connections([first, second, third]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::ExactlyOnce))).unwrap();
+    publish_qos2_ok(&mut session, "data", b"x");
 
     match poll_now(&mut session) {
         Ok(None) | Err(Error::Disconnected) => {}
@@ -1333,10 +1362,10 @@ fn fresh_session_after_reconnect_drops_stale_replay_state() {
     second.push_rx(&connack());
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
 
     expect_disconnected(&mut session);
     expect_connected(&mut session, &connector);
@@ -1364,10 +1393,10 @@ fn fresh_session_failed_connack_still_drops_stale_replay_state() {
     third.push_rx(&connack());
 
     let connector = MockConnector::with_connections([first, second, third]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
 
     expect_disconnected(&mut session);
     assert!(matches!(
@@ -1397,10 +1426,10 @@ fn stale_puback_after_resumed_replay_is_ignored() {
     second.push_rx(&puback(1));
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
-    block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))).unwrap();
+    publish_qos1_ok(&mut session, "data", b"x");
 
     expect_disconnected(&mut session);
     expect_reconnected(&mut session, &connector);
@@ -1502,7 +1531,7 @@ fn unsubscribe_replays_until_unsuback() {
     second.push_rx(&unsuback(1, 0x00));
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = Session::new(config());
+    let mut session = session();
 
     expect_connected(&mut session, &connector);
     block_on(session.unsubscribe(&["data"], &[])).unwrap();

--- a/tests/async_client.rs
+++ b/tests/async_client.rs
@@ -357,7 +357,7 @@ fn poll_now<'a>(
     session: &'a mut Session<'static, MockConnection>,
 ) -> Result<Option<InboundPublish<'a>>, Error<ErrorKind>> {
     match block_on(with_timeout(Duration::from_millis(0), session.poll())) {
-        Ok(Ok(event)) => Ok(Some(event)),
+        Ok(Ok(event)) => Ok(event),
         Ok(Err(err)) => Err(err),
         Err(_) => Ok(None),
     }
@@ -378,7 +378,7 @@ fn with_inbound<T>(
     session: &mut Session<'static, MockConnection>,
     f: impl FnOnce(minimq::InboundPublish<'_>) -> T,
 ) -> T {
-    f(block_on(session.poll()).unwrap())
+    f(block_on(session.recv()).unwrap())
 }
 
 fn expect_poll_error(
@@ -429,7 +429,8 @@ fn fill_inflight_publish_slots(session: &mut Session<'static, MockConnection>) -
     let mut count = 0;
     loop {
         match block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))) {
-            Ok(()) => count += 1,
+            Ok(Some(_)) => count += 1,
+            Ok(None) => unreachable!("QoS1 publish must return an op handle"),
             Err(PubError::Session(Error::Protocol(ProtocolError::InflightMetadataExhausted))) => {
                 return count;
             }
@@ -524,7 +525,8 @@ fn cancelled_publish_still_holds_receive_max_quota() {
     assert!(matches!(result, Err(PubError::Session(Error::NotReady))));
     for _ in 0..WAIT_STEPS {
         match block_on(session.publish(Publication::bytes("data", b"z").qos(QoS::AtLeastOnce))) {
-            Ok(()) => return,
+            Ok(Some(_)) => return,
+            Ok(None) => unreachable!("QoS1 publish must return an op handle"),
             Err(PubError::Session(Error::NotReady)) => {
                 assert!(poll_now(&mut session).unwrap().is_none());
             }

--- a/tests/async_client.rs
+++ b/tests/async_client.rs
@@ -3,8 +3,9 @@ mod support;
 use embassy_time::{Duration, with_timeout};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use minimq::{
-    Buffers, ConfigBuilder, ConnectEvent, Error, InboundPublish, ProtocolError, PubError,
-    Publication, QoS, Session,
+    Buffers, ConfigBuilder, ConnectEvent, Error, InboundPublish, Property, ProtocolError,
+    PubError, Publication, QoS, ReasonCode, Session,
+    types::{BinaryData, Properties, TopicFilter},
 };
 use std::{cell::RefCell, collections::VecDeque, future::poll_fn, rc::Rc, task::Poll};
 use support::{block_on, poll_once};
@@ -376,7 +377,7 @@ fn expect_disconnected(session: &mut Session<'static, MockConnection>) {
 
 fn with_inbound<T>(
     session: &mut Session<'static, MockConnection>,
-    f: impl FnOnce(minimq::InboundPublish<'_>) -> T,
+    f: impl FnOnce(InboundPublish<'_>) -> T,
 ) -> T {
     f(block_on(session.recv()).unwrap())
 }
@@ -546,7 +547,7 @@ fn subscribe_survives_cancellation_during_pending_flush() {
     let mut session = connected_session(&connector);
 
     inspect.pend_flushes(1);
-    let topics = [minimq::types::TopicFilter::new("data")];
+    let topics = [TopicFilter::new("data")];
     let mut future = Box::pin(session.subscribe(&topics, &[]));
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
@@ -671,9 +672,7 @@ fn failed_connack_disconnects_session_and_allows_reconnect() {
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
-        Err(Error::Protocol(ProtocolError::Failed(
-            minimq::ReasonCode::NotAuthorized
-        )))
+        Err(Error::Protocol(ProtocolError::Failed(ReasonCode::NotAuthorized)))
     ));
     assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
@@ -810,7 +809,7 @@ fn subscribe_is_replayed_after_disconnect_until_suback() {
     let mut session = Session::new(config());
 
     expect_connected(&mut session, &connector);
-    block_on(session.subscribe(&[minimq::types::TopicFilter::new("data")], &[])).unwrap();
+    block_on(session.subscribe(&[TopicFilter::new("data")], &[])).unwrap();
     expect_disconnected(&mut session);
     expect_reconnected(&mut session, &connector);
     wait_for_tx_frame(
@@ -839,7 +838,7 @@ fn subscribe_reports_inflight_metadata_exhaustion_before_send() {
 
     let capacity = fill_inflight_publish_slots(&mut session);
 
-    let result = block_on(session.subscribe(&[minimq::types::TopicFilter::new("data")], &[]));
+    let result = block_on(session.subscribe(&[TopicFilter::new("data")], &[]));
     assert!(matches!(
         result,
         Err(Error::Protocol(ProtocolError::InflightMetadataExhausted))
@@ -1079,7 +1078,7 @@ fn puback_failure_is_reported_and_clears_inflight() {
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
-            Error::Protocol(ProtocolError::Failed(minimq::ReasonCode::NotAuthorized))
+            Error::Protocol(ProtocolError::Failed(ReasonCode::NotAuthorized))
         )
     });
     block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::AtLeastOnce))).unwrap();
@@ -1097,7 +1096,7 @@ fn pubrec_failure_is_reported_and_clears_inflight() {
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
-            Error::Protocol(ProtocolError::Failed(minimq::ReasonCode::QuotaExceeded))
+            Error::Protocol(ProtocolError::Failed(ReasonCode::QuotaExceeded))
         )
     });
     block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::ExactlyOnce))).unwrap();
@@ -1117,7 +1116,7 @@ fn pubcomp_failure_is_reported_and_clears_release_state() {
         matches!(
             err,
             Error::Protocol(ProtocolError::Failed(
-                minimq::ReasonCode::ImplementationError
+                ReasonCode::ImplementationError
             ))
         )
     });
@@ -1459,7 +1458,7 @@ fn publish_rejects_packets_larger_than_broker_maximum() {
     assert!(matches!(
         result,
         Err(PubError::Session(Error::Protocol(ProtocolError::Failed(
-            minimq::ReasonCode::PacketTooLarge
+            ReasonCode::PacketTooLarge
         ))))
     ));
     assert_eq!(inspect.tx().len(), 1);
@@ -1480,7 +1479,7 @@ fn oversized_required_ack_disconnects_session() {
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
-            Error::Protocol(ProtocolError::Failed(minimq::ReasonCode::PacketTooLarge))
+            Error::Protocol(ProtocolError::Failed(ReasonCode::PacketTooLarge))
         )
     });
     expect_connected(&mut session, &connector);
@@ -1542,7 +1541,7 @@ fn unsubscribe_rejects_packets_larger_than_broker_maximum() {
     assert!(matches!(
         result,
         Err(Error::Protocol(ProtocolError::Failed(
-            minimq::ReasonCode::PacketTooLarge
+            ReasonCode::PacketTooLarge
         )))
     ));
     assert_eq!(inspect.tx().len(), 1);
@@ -1556,11 +1555,11 @@ fn subscribe_rejects_packets_larger_than_broker_maximum() {
     let connector = MockConnector::new(connection);
     let mut session = connected_session(&connector);
 
-    let result = block_on(session.subscribe(&[minimq::types::TopicFilter::new("data")], &[]));
+    let result = block_on(session.subscribe(&[TopicFilter::new("data")], &[]));
     assert!(matches!(
         result,
         Err(Error::Protocol(ProtocolError::Failed(
-            minimq::ReasonCode::PacketTooLarge
+            ReasonCode::PacketTooLarge
         )))
     ));
     assert_eq!(inspect.tx().len(), 1);
@@ -1589,12 +1588,12 @@ fn inbound_publish_exposes_response_helpers() {
         let follow_up = owned_via_message.publication("next");
 
         let response = match reply.properties_ref() {
-            minimq::types::Properties::CorrelatedSlice { correlation, .. } => correlation,
+            Properties::CorrelatedSlice { correlation, .. } => correlation,
             _ => panic!("reply should preserve correlation data"),
         };
         assert!(matches!(
             response,
-            minimq::Property::CorrelationData(minimq::types::BinaryData(b"abc"))
+            Property::CorrelationData(BinaryData(b"abc"))
         ));
         assert_eq!(owned_via_message.topic(), "reply/topic");
         let _ = follow_up;

--- a/tests/async_client.rs
+++ b/tests/async_client.rs
@@ -3,8 +3,8 @@ mod support;
 use embassy_time::{Duration, with_timeout};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use minimq::{
-    Buffers, ConfigBuilder, ConnectEvent, Error, InboundPublish, Property, ProtocolError,
-    PubError, Publication, QoS, ReasonCode, Session,
+    Buffers, ConfigBuilder, ConnectEvent, Error, InboundPublish, PeerError, Property, PubError,
+    Publication, QoS, ReasonCode, ResourceError, Session,
     types::{BinaryData, Properties, TopicFilter},
 };
 use std::{cell::RefCell, collections::VecDeque, future::poll_fn, rc::Rc, task::Poll};
@@ -432,7 +432,7 @@ fn fill_inflight_publish_slots(session: &mut Session<'static, MockConnection>) -
         match block_on(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce))) {
             Ok(Some(_)) => count += 1,
             Ok(None) => unreachable!("QoS1 publish must return an op handle"),
-            Err(PubError::Session(Error::Protocol(ProtocolError::InflightMetadataExhausted))) => {
+            Err(PubError::Session(Error::Resource(ResourceError::InflightExhausted))) => {
                 return count;
             }
             other => panic!("unexpected publish result while filling inflight slots: {other:?}"),
@@ -672,7 +672,7 @@ fn failed_connack_disconnects_session_and_allows_reconnect() {
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
-        Err(Error::Protocol(ProtocolError::Failed(ReasonCode::NotAuthorized)))
+        Err(Error::Peer(PeerError::Rejected(ReasonCode::NotAuthorized)))
     ));
     assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
@@ -706,7 +706,7 @@ fn zero_receive_maximum_disconnects_session_and_allows_reconnect() {
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
-        Err(Error::Protocol(ProtocolError::InvalidProperty))
+        Err(Error::Peer(PeerError::InvalidPacket))
     ));
     assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
@@ -723,7 +723,7 @@ fn oversized_assigned_client_id_disconnects_session_and_allows_reconnect() {
 
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
-        Err(Error::Protocol(ProtocolError::ProvidedClientIdTooLong))
+        Err(Error::Peer(PeerError::InvalidPacket))
     ));
     assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
@@ -759,7 +759,7 @@ fn malformed_inbound_packet_disconnects_session_and_allows_reconnect() {
 
     expect_connected(&mut session, &connector);
     expect_poll_error(&mut session, |err| {
-        matches!(err, Error::Protocol(ProtocolError::MalformedPacket))
+        matches!(err, Error::Peer(PeerError::InvalidPacket))
     });
     assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
@@ -841,7 +841,7 @@ fn subscribe_reports_inflight_metadata_exhaustion_before_send() {
     let result = block_on(session.subscribe(&[TopicFilter::new("data")], &[]));
     assert!(matches!(
         result,
-        Err(Error::Protocol(ProtocolError::InflightMetadataExhausted))
+        Err(Error::Resource(ResourceError::InflightExhausted))
     ));
     assert_eq!(inspect.tx().len(), capacity + 1);
 }
@@ -854,10 +854,7 @@ fn subscribe_rejects_empty_topic_list() {
     let mut session = connected_session(&connector);
 
     let result = block_on(session.subscribe(&[], &[]));
-    assert!(matches!(
-        result,
-        Err(Error::Protocol(ProtocolError::NoTopic))
-    ));
+    assert!(matches!(result, Err(Error::InvalidRequest)));
 }
 
 #[test]
@@ -868,10 +865,7 @@ fn unsubscribe_rejects_empty_topic_list() {
     let mut session = connected_session(&connector);
 
     let result = block_on(session.unsubscribe(&[], &[]));
-    assert!(matches!(
-        result,
-        Err(Error::Protocol(ProtocolError::NoTopic))
-    ));
+    assert!(matches!(result, Err(Error::InvalidRequest)));
 }
 
 #[test]
@@ -1078,7 +1072,7 @@ fn puback_failure_is_reported_and_clears_inflight() {
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
-            Error::Protocol(ProtocolError::Failed(ReasonCode::NotAuthorized))
+            Error::Peer(PeerError::Rejected(ReasonCode::NotAuthorized))
         )
     });
     block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::AtLeastOnce))).unwrap();
@@ -1096,7 +1090,7 @@ fn pubrec_failure_is_reported_and_clears_inflight() {
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
-            Error::Protocol(ProtocolError::Failed(ReasonCode::QuotaExceeded))
+            Error::Peer(PeerError::Rejected(ReasonCode::QuotaExceeded))
         )
     });
     block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::ExactlyOnce))).unwrap();
@@ -1115,9 +1109,7 @@ fn pubcomp_failure_is_reported_and_clears_release_state() {
     expect_poll_error(&mut session, |err| {
         matches!(
             err,
-            Error::Protocol(ProtocolError::Failed(
-                ReasonCode::ImplementationError
-            ))
+            Error::Peer(PeerError::Rejected(ReasonCode::ImplementationError))
         )
     });
     block_on(session.publish(Publication::bytes("data", b"y").qos(QoS::ExactlyOnce))).unwrap();
@@ -1380,7 +1372,7 @@ fn fresh_session_failed_connack_still_drops_stale_replay_state() {
     expect_disconnected(&mut session);
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
-        Err(Error::Protocol(ProtocolError::InvalidProperty))
+        Err(Error::Peer(PeerError::InvalidPacket))
     ));
     expect_connected(&mut session, &connector);
     assert!(poll_now(&mut session).unwrap().is_none());
@@ -1457,9 +1449,9 @@ fn publish_rejects_packets_larger_than_broker_maximum() {
     let result = block_on(session.publish(Publication::bytes("data", b"x")));
     assert!(matches!(
         result,
-        Err(PubError::Session(Error::Protocol(ProtocolError::Failed(
-            ReasonCode::PacketTooLarge
-        ))))
+        Err(PubError::Session(Error::Resource(
+            ResourceError::PacketTooLarge
+        )))
     ));
     assert_eq!(inspect.tx().len(), 1);
 }
@@ -1477,10 +1469,7 @@ fn oversized_required_ack_disconnects_session() {
     let mut session = connected_session(&connector);
 
     expect_poll_error(&mut session, |err| {
-        matches!(
-            err,
-            Error::Protocol(ProtocolError::Failed(ReasonCode::PacketTooLarge))
-        )
+        matches!(err, Error::Resource(ResourceError::PacketTooLarge))
     });
     expect_connected(&mut session, &connector);
 }
@@ -1540,9 +1529,7 @@ fn unsubscribe_rejects_packets_larger_than_broker_maximum() {
     let result = block_on(session.unsubscribe(&["data"], &[]));
     assert!(matches!(
         result,
-        Err(Error::Protocol(ProtocolError::Failed(
-            ReasonCode::PacketTooLarge
-        )))
+        Err(Error::Resource(ResourceError::PacketTooLarge))
     ));
     assert_eq!(inspect.tx().len(), 1);
 }
@@ -1558,9 +1545,7 @@ fn subscribe_rejects_packets_larger_than_broker_maximum() {
     let result = block_on(session.subscribe(&[TopicFilter::new("data")], &[]));
     assert!(matches!(
         result,
-        Err(Error::Protocol(ProtocolError::Failed(
-            ReasonCode::PacketTooLarge
-        )))
+        Err(Error::Resource(ResourceError::PacketTooLarge))
     ));
     assert_eq!(inspect.tx().len(), 1);
 }

--- a/tests/real_broker.rs
+++ b/tests/real_broker.rs
@@ -118,13 +118,14 @@ async fn poll_until_ready(
             with_timeout(Duration::from_millis(0), session.poll()).await
         };
         match result {
-            Ok(Ok(message)) if want_inbound => {
+            Ok(Ok(Some(message))) if want_inbound => {
                 return Some((
                     message.topic().to_string(),
                     message.payload().to_vec(),
                     message.qos(),
                 ));
             }
+            Ok(Ok(None)) => {}
             Err(_) if !want_inbound => return None,
             Ok(Err(Error::Transport(err))) => match err.kind() {
                 std::io::ErrorKind::TimedOut | std::io::ErrorKind::Interrupted => {}


### PR DESCRIPTION
- **reduce mono-bloat, clean up pub, simplify error conv**
- **add op status, cooperative drive()**
- **own topic**
- **naming cleanup**
- **example: simplify**
- **errors: re-layer, make useful**
- **clean up tests**
