### PR TITLE
packet size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+DEFMT_LOG = "off"
+

--- a/src/de/packet_reader.rs
+++ b/src/de/packet_reader.rs
@@ -18,6 +18,10 @@ impl<'a> PacketReader<'a> {
         }
     }
 
+    pub fn capacity(&self) -> usize {
+        self.buffer.len()
+    }
+
     pub fn receive_buffer(&mut self) -> Result<&mut [u8], Error> {
         if self.packet_length.is_none() {
             self.probe_fixed_header()?;

--- a/src/mqtt_client/session/mod.rs
+++ b/src/mqtt_client/session/mod.rs
@@ -81,6 +81,16 @@ where
         self.connection.is_some()
     }
 
+    /// Return the maximum inbound MQTT packet size accepted by this session.
+    pub fn max_rx_packet_size(&self) -> usize {
+        self.packet_reader.capacity()
+    }
+
+    /// Return the maximum outbound MQTT packet arena size available to this session.
+    pub fn max_tx_packet_size(&self) -> usize {
+        self.data.outbound.capacity()
+    }
+
     /// Return whether the session currently has the local capacity to attempt a
     /// publish at the requested QoS.
     pub fn can_publish(&mut self, qos: QoS) -> bool {

--- a/src/mqtt_client/session/tests.rs
+++ b/src/mqtt_client/session/tests.rs
@@ -65,6 +65,14 @@ fn session() -> Session<'static, MockConnection> {
 }
 
 #[test]
+fn session_exposes_local_packet_capacities() {
+    let session = session();
+
+    assert_eq!(session.max_rx_packet_size(), 128);
+    assert_eq!(session.max_tx_packet_size(), 1152);
+}
+
+#[test]
 fn maintain_sends_pingreq_when_due() {
     let mut session = session();
     session.connection = Some(MockConnection::default());


### PR DESCRIPTION
- **Expose MQTT session packet capacities**
- **explicitly disable defmt logging by default when top crate**
