### PR TITLE
Add derive `defmt::Format` for `Error` enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ impl<P, T> From<ProtocolError> for PubError<P, T> {
 
 /// Possible errors encountered during MQTT operation.
 #[derive(Debug, PartialEq, thiserror::Error)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error<E> {
     /// Local buffers or in-flight state are not currently ready for the requested operation.


### PR DESCRIPTION
It only impl `defmt::Format` when `E: defmt::Format`, so no breaking changes