### PR TITLE
Split transport IO out of `Session` into a `Connection` handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/quartiq/minimq/compare/v0.12.0...HEAD)
+
+## Changed
+
+* **Breaking:** `Session` no longer carries the transport `IO` type parameter. `Session::connect()`
+  now returns a `Connection` handle that owns the transport and borrows the session; the network
+  operations (`drive`/`poll`/`recv`/`publish`/`subscribe`/`unsubscribe`/`disconnect`) move onto the
+  handle, while session-state queries remain reachable through its `Deref` to `Session`. This lets a
+  single `Session` be reused across reconnects with transports of different types or buffer
+  lifetimes — for example reusing TLS record buffers instead of leaking a fresh pair per connection.
+* **Breaking:** `is_connected()` moves from `Session` to the `Connection` handle and now reports
+  *per-connection* liveness: it latches `false` as soon as any operation observes a transport- or
+  protocol-level disconnect (broker `DISCONNECT`, transport error, keepalive timeout) or a graceful
+  `disconnect`, after which further operations on the handle fail fast with `Error::Disconnected`
+  instead of driving the dead transport.
+
 ## [v0.12.0](https://github.com/quartiq/minimq/compare/v0.11.2..v0.12.0) - 2026-05-24
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **Breaking:** `Session` no longer carries the transport `IO` type parameter. `Session::connect()`
   now returns a `Connection` handle that owns the transport and borrows the session; the network
   operations (`drive`/`poll`/`recv`/`publish`/`subscribe`/`unsubscribe`/`disconnect`) move onto the
-  handle, while session-state queries remain reachable through its `Deref` to `Session`. This lets a
-  single `Session` be reused across reconnects with transports of different types or buffer
-  lifetimes — for example reusing TLS record buffers instead of leaking a fresh pair per connection.
+  handle.
 * **Breaking:** `is_connected()` moves from `Session` to the `Connection` handle and now reports
   *per-connection* liveness: it latches `false` as soon as any operation observes a transport- or
   protocol-level disconnect (broker `DISCONNECT`, transport error, keepalive timeout) or a graceful

--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ async fn run() {
 
     loop {
         let io = open_io(addr).await.unwrap();
-        match session.connect(io).await.unwrap() {
+        // `connect` returns a connection handle that owns the transport and borrows
+        // the session. Dropping it at the end of the loop releases both for the next
+        // reconnect.
+        let mut conn = session.connect(io).await.unwrap();
+        match conn.connect_event() {
             ConnectEvent::Connected => {
-                session
-                    .subscribe(&[TopicFilter::new("demo/in")], &[])
+                conn.subscribe(&[TopicFilter::new("demo/in")], &[])
                     .await
                     .unwrap();
             }
@@ -68,7 +71,7 @@ async fn run() {
         }
 
         loop {
-            match session.recv().await {
+            match conn.recv().await {
                 Ok(message) => println!("topic={}", message.topic()),
                 Err(Error::Disconnected) => break,
                 Err(err) => panic!("{err}"),

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -51,7 +51,7 @@ async fn run() -> Result<(), Box<dyn StdError>> {
     let mut subscriber = Session::new(
         ConfigBuilder::from_buffer(&mut sub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
     );
-    subscriber
+    let mut subscriber = subscriber
         .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
         .await?;
     let sub = subscriber
@@ -65,7 +65,7 @@ async fn run() -> Result<(), Box<dyn StdError>> {
     let mut publisher = Session::new(
         ConfigBuilder::from_buffer(&mut pub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
     );
-    publisher
+    let mut publisher = publisher
         .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
         .await?;
     let pub_ = publisher

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -1,11 +1,17 @@
 //! TLS connectivity example for `embedded-tls`.
 //!
-//! Use this as a TLS transport example. Bounded/cooperative session driving is done by wrapping
-//! the cancel-safe blocking `Session::poll()` in an external timeout at the call site.
+//! It also showcases the connection-handle API: the transport lives in the
+//! [`Connection`](minimq::Connection) handle returned by [`Session::connect`], not in the
+//! `Session`, so the TLS record buffers only need to live as long as one connection. A single pair
+//! of record buffers is owned here and re-lent to every connection, so one allocation serves every
+//! reconnect.
 
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
-use minimq::{ConfigBuilder, Publication, QoS, Session, TopicFilter};
+use minimq::{
+    ConfigBuilder, ConnectEvent, Connection, Error, Io, PubError, Publication, QoS, Session,
+    TopicFilter,
+};
 use std::error::Error as StdError;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpStream;
@@ -17,17 +23,28 @@ const PASSWORD: &str = "public";
 const TLS_READ_RECORD_BUFFER_LEN: usize = 16_640;
 const TLS_WRITE_RECORD_BUFFER_LEN: usize = 4_096;
 
-async fn connect_tls(
+/// Number of successful round-trips to perform before exiting. A real long-running client would
+/// loop forever; we stop after a few so the example terminates while still reconnecting (and so
+/// reusing the record buffers) more than once.
+const ROUND_TRIPS: usize = 2;
+
+/// Open a TLS connection over the caller-owned record buffers.
+///
+/// The returned connection borrows `read_record`/`write_record` for its own lifetime `'a`, not
+/// `'static`, which is what lets the caller reuse the buffers once the connection is dropped.
+async fn connect_tls<'a>(
     host: &str,
     port: u16,
-) -> Result<TlsConnection<'static, FromTokio<TcpStream>, Aes128GcmSha256>, Box<dyn StdError>> {
+    read_record: &'a mut [u8],
+    write_record: &'a mut [u8],
+) -> Result<TlsConnection<'a, FromTokio<TcpStream>, Aes128GcmSha256>, Box<dyn StdError>> {
     let config = TlsConfig::new()
         .with_server_name(host)
         .enable_rsa_signatures();
     let mut tls = TlsConnection::new(
         FromTokio::new(TcpStream::connect((host, port)).await?),
-        Box::leak(Box::new([0u8; TLS_READ_RECORD_BUFFER_LEN])),
-        Box::leak(Box::new([0u8; TLS_WRITE_RECORD_BUFFER_LEN])),
+        read_record,
+        write_record,
     );
     let mut provider = UnsecureProvider::new::<Aes128GcmSha256>(rand::rngs::OsRng);
     tls.open(TlsContext::new(&config, &mut provider)).await?;
@@ -42,51 +59,110 @@ fn unique_id(label: &str) -> String {
     format!("minimq-{label}-{nanos}")
 }
 
-async fn run() -> Result<(), Box<dyn StdError>> {
-    let topic = format!("minimq/examples/tls/{}", unique_id("topic"));
-    let payload_str = format!("hello over tls {}", unique_id("msg"));
-    let payload = payload_str.as_bytes();
-
-    let mut sub_storage = [0u8; 2048];
-    let mut subscriber = Session::new(
-        ConfigBuilder::from_buffer(&mut sub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
-    );
-    let mut subscriber = subscriber
-        .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
-        .await?;
-    let sub = subscriber
-        .subscribe(&[TopicFilter::new(&topic)], &[])
-        .await?;
-    while subscriber.is_pending(&sub) {
-        subscriber.poll().await?;
+/// Subscribe, publish one message, and wait to receive it back over the same connection.
+///
+/// Errors are returned rather than handled here so the caller can decide whether a failure means
+/// "reconnect" or "give up".
+async fn round_trip<C: Io>(
+    conn: &mut Connection<'_, '_, C>,
+    topic: &str,
+    payload: &[u8],
+) -> Result<(), Error<C::Error>> {
+    // A resumed session keeps its broker-side subscriptions, so only (re)subscribe on a session
+    // the broker reports as fresh.
+    if matches!(conn.connect_event(), ConnectEvent::Connected) {
+        let sub = conn.subscribe(&[TopicFilter::new(topic)], &[]).await?;
+        while conn.is_pending(&sub) {
+            conn.poll().await?;
+        }
     }
 
-    let mut pub_storage = [0u8; 2048];
-    let mut publisher = Session::new(
-        ConfigBuilder::from_buffer(&mut pub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
-    );
-    let mut publisher = publisher
-        .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
-        .await?;
-    let pub_ = publisher
-        .publish(Publication::new(&topic, payload).qos(QoS::AtLeastOnce))
-        .await?
-        .unwrap();
-    while publisher.is_pending(&pub_) {
-        publisher.poll().await?;
+    let op = match conn
+        .publish(Publication::new(topic, payload).qos(QoS::AtLeastOnce))
+        .await
+    {
+        Ok(op) => op.expect("a QoS 1 publish yields an operation handle"),
+        Err(PubError::Session(err)) => return Err(err),
+        // A `&[u8]` payload is copied verbatim and cannot fail to serialize.
+        Err(PubError::Payload(())) => unreachable!("byte-slice payloads are infallible"),
+    };
+    while conn.is_pending(&op) {
+        conn.poll().await?;
     }
 
     loop {
-        let message = subscriber.recv().await?;
+        let message = conn.recv().await?;
         if message.topic() == topic && message.payload() == payload {
-            println!(
-                "received topic={} payload={}",
-                message.topic(),
-                payload.escape_ascii()
-            );
             return Ok(());
         }
     }
+}
+
+async fn run() -> Result<(), Box<dyn StdError>> {
+    let topic = format!("minimq/examples/tls/{}", unique_id("topic"));
+
+    // Owned once and re-lent to every connection below: one pair of record buffers serves every
+    // reconnect, with no `Box::leak` and no per-connection allocation.
+    let mut read_record = vec![0u8; TLS_READ_RECORD_BUFFER_LEN];
+    let mut write_record = vec![0u8; TLS_WRITE_RECORD_BUFFER_LEN];
+
+    let mut session_storage = [0u8; 2048];
+    let mut session = Session::new(
+        ConfigBuilder::from_buffer(&mut session_storage, 1024)?
+            .auth(USERNAME, PASSWORD.as_bytes())?,
+    );
+
+    // The correct shape for an MQTT client is an outer loop that reconnects instead of bailing out
+    // when a connection drops. Every iteration borrows the same record buffers for the new
+    // connection.
+    let mut completed = 0;
+    while completed < ROUND_TRIPS {
+        let tls = match connect_tls(
+            BROKER_HOST,
+            BROKER_PORT,
+            &mut read_record[..],
+            &mut write_record[..],
+        )
+        .await
+        {
+            Ok(tls) => tls,
+            Err(err) => {
+                eprintln!("transport connect failed ({err}); retrying");
+                continue;
+            }
+        };
+
+        let mut conn = match session.connect(tls).await {
+            Ok(conn) => conn,
+            Err(err) => {
+                eprintln!("MQTT connect failed ({err}); retrying");
+                continue;
+            }
+        };
+
+        let payload = format!("hello over tls #{completed}");
+        match round_trip(&mut conn, &topic, payload.as_bytes()).await {
+            Ok(()) => {
+                println!("round-trip {completed} ok");
+                completed += 1;
+
+                // Close gracefully: this sends an MQTT DISCONNECT, so the broker tears the session
+                // down cleanly and does not publish the Will. Just dropping `conn` here instead
+                // would be an abnormal close — the broker would treat it as a lost connection and
+                // publish the configured Will, if any.
+                conn.disconnect().await?;
+            }
+            // Losing the connection mid-exchange is a normal operational event: reconnect and reuse
+            // the same record buffers. Letting `conn` drop on the way out of this arm is correct —
+            // there is nothing left to send on a dead transport.
+            Err(Error::Disconnected) | Err(Error::Transport(_)) => {
+                eprintln!("connection lost mid-exchange; reconnecting");
+            }
+            Err(other) => return Err(other.into()),
+        }
+    }
+
+    Ok(())
 }
 
 #[tokio::main]

--- a/examples/tls_public_broker.rs
+++ b/examples/tls_public_broker.rs
@@ -1,17 +1,11 @@
 //! TLS connectivity example for `embedded-tls`.
 //!
-//! It also showcases the connection-handle API: the transport lives in the
-//! [`Connection`](minimq::Connection) handle returned by [`Session::connect`], not in the
-//! `Session`, so the TLS record buffers only need to live as long as one connection. A single pair
-//! of record buffers is owned here and re-lent to every connection, so one allocation serves every
-//! reconnect.
+//! Use this as a TLS transport example. Bounded/cooperative session driving is done by wrapping
+//! the cancel-safe blocking `Session::poll()` in an external timeout at the call site.
 
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
-use minimq::{
-    ConfigBuilder, ConnectEvent, Connection, Error, Io, PubError, Publication, QoS, Session,
-    TopicFilter,
-};
+use minimq::{ConfigBuilder, Publication, QoS, Session, TopicFilter};
 use std::error::Error as StdError;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpStream;
@@ -23,28 +17,17 @@ const PASSWORD: &str = "public";
 const TLS_READ_RECORD_BUFFER_LEN: usize = 16_640;
 const TLS_WRITE_RECORD_BUFFER_LEN: usize = 4_096;
 
-/// Number of successful round-trips to perform before exiting. A real long-running client would
-/// loop forever; we stop after a few so the example terminates while still reconnecting (and so
-/// reusing the record buffers) more than once.
-const ROUND_TRIPS: usize = 2;
-
-/// Open a TLS connection over the caller-owned record buffers.
-///
-/// The returned connection borrows `read_record`/`write_record` for its own lifetime `'a`, not
-/// `'static`, which is what lets the caller reuse the buffers once the connection is dropped.
-async fn connect_tls<'a>(
+async fn connect_tls(
     host: &str,
     port: u16,
-    read_record: &'a mut [u8],
-    write_record: &'a mut [u8],
-) -> Result<TlsConnection<'a, FromTokio<TcpStream>, Aes128GcmSha256>, Box<dyn StdError>> {
+) -> Result<TlsConnection<'static, FromTokio<TcpStream>, Aes128GcmSha256>, Box<dyn StdError>> {
     let config = TlsConfig::new()
         .with_server_name(host)
         .enable_rsa_signatures();
     let mut tls = TlsConnection::new(
         FromTokio::new(TcpStream::connect((host, port)).await?),
-        read_record,
-        write_record,
+        Box::leak(Box::new([0u8; TLS_READ_RECORD_BUFFER_LEN])),
+        Box::leak(Box::new([0u8; TLS_WRITE_RECORD_BUFFER_LEN])),
     );
     let mut provider = UnsecureProvider::new::<Aes128GcmSha256>(rand::rngs::OsRng);
     tls.open(TlsContext::new(&config, &mut provider)).await?;
@@ -59,110 +42,53 @@ fn unique_id(label: &str) -> String {
     format!("minimq-{label}-{nanos}")
 }
 
-/// Subscribe, publish one message, and wait to receive it back over the same connection.
-///
-/// Errors are returned rather than handled here so the caller can decide whether a failure means
-/// "reconnect" or "give up".
-async fn round_trip<C: Io>(
-    conn: &mut Connection<'_, '_, C>,
-    topic: &str,
-    payload: &[u8],
-) -> Result<(), Error<C::Error>> {
-    // A resumed session keeps its broker-side subscriptions, so only (re)subscribe on a session
-    // the broker reports as fresh.
-    if matches!(conn.connect_event(), ConnectEvent::Connected) {
-        let sub = conn.subscribe(&[TopicFilter::new(topic)], &[]).await?;
-        while conn.is_pending(&sub) {
-            conn.poll().await?;
-        }
+async fn run() -> Result<(), Box<dyn StdError>> {
+    let topic = format!("minimq/examples/tls/{}", unique_id("topic"));
+    let payload_str = format!("hello over tls {}", unique_id("msg"));
+    let payload = payload_str.as_bytes();
+
+    let mut sub_storage = [0u8; 2048];
+    let mut session = Session::new(
+        ConfigBuilder::from_buffer(&mut sub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
+    );
+    let mut subscriber = session
+        .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
+        .await?;
+    let sub = subscriber
+        .subscribe(&[TopicFilter::new(&topic)], &[])
+        .await?;
+    while subscriber.is_pending(&sub) {
+        subscriber.poll().await?;
     }
 
-    let op = match conn
-        .publish(Publication::new(topic, payload).qos(QoS::AtLeastOnce))
-        .await
-    {
-        Ok(op) => op.expect("a QoS 1 publish yields an operation handle"),
-        Err(PubError::Session(err)) => return Err(err),
-        // A `&[u8]` payload is copied verbatim and cannot fail to serialize.
-        Err(PubError::Payload(())) => unreachable!("byte-slice payloads are infallible"),
-    };
-    while conn.is_pending(&op) {
-        conn.poll().await?;
+    let mut pub_storage = [0u8; 2048];
+    let mut session = Session::new(
+        ConfigBuilder::from_buffer(&mut pub_storage, 1024)?.auth(USERNAME, PASSWORD.as_bytes())?,
+    );
+    let mut publisher = session
+        .connect(connect_tls(BROKER_HOST, BROKER_PORT).await?)
+        .await?;
+    let pub_ = publisher
+        .publish(Publication::new(&topic, payload).qos(QoS::AtLeastOnce))
+        .await?
+        .unwrap();
+    while publisher.is_pending(&pub_) {
+        publisher.poll().await?;
     }
 
     loop {
-        let message = conn.recv().await?;
+        let message = subscriber.recv().await?;
         if message.topic() == topic && message.payload() == payload {
+            println!(
+                "received topic={} payload={}",
+                message.topic(),
+                payload.escape_ascii()
+            );
+            publisher.disconnect().await?;
+            subscriber.disconnect().await?;
             return Ok(());
         }
     }
-}
-
-async fn run() -> Result<(), Box<dyn StdError>> {
-    let topic = format!("minimq/examples/tls/{}", unique_id("topic"));
-
-    // Owned once and re-lent to every connection below: one pair of record buffers serves every
-    // reconnect, with no `Box::leak` and no per-connection allocation.
-    let mut read_record = vec![0u8; TLS_READ_RECORD_BUFFER_LEN];
-    let mut write_record = vec![0u8; TLS_WRITE_RECORD_BUFFER_LEN];
-
-    let mut session_storage = [0u8; 2048];
-    let mut session = Session::new(
-        ConfigBuilder::from_buffer(&mut session_storage, 1024)?
-            .auth(USERNAME, PASSWORD.as_bytes())?,
-    );
-
-    // The correct shape for an MQTT client is an outer loop that reconnects instead of bailing out
-    // when a connection drops. Every iteration borrows the same record buffers for the new
-    // connection.
-    let mut completed = 0;
-    while completed < ROUND_TRIPS {
-        let tls = match connect_tls(
-            BROKER_HOST,
-            BROKER_PORT,
-            &mut read_record[..],
-            &mut write_record[..],
-        )
-        .await
-        {
-            Ok(tls) => tls,
-            Err(err) => {
-                eprintln!("transport connect failed ({err}); retrying");
-                continue;
-            }
-        };
-
-        let mut conn = match session.connect(tls).await {
-            Ok(conn) => conn,
-            Err(err) => {
-                eprintln!("MQTT connect failed ({err}); retrying");
-                continue;
-            }
-        };
-
-        let payload = format!("hello over tls #{completed}");
-        match round_trip(&mut conn, &topic, payload.as_bytes()).await {
-            Ok(()) => {
-                println!("round-trip {completed} ok");
-                completed += 1;
-
-                // Close gracefully: this sends an MQTT DISCONNECT, so the broker tears the session
-                // down cleanly and does not publish the Will. Just dropping `conn` here instead
-                // would be an abnormal close — the broker would treat it as a lost connection and
-                // publish the configured Will, if any.
-                conn.disconnect().await?;
-            }
-            // Losing the connection mid-exchange is a normal operational event: reconnect and reuse
-            // the same record buffers. Letting `conn` drop on the way out of this arm is correct —
-            // there is nothing left to send on a dead transport.
-            Err(Error::Disconnected) | Err(Error::Transport(_)) => {
-                eprintln!("connection lost mid-exchange; reconnecting");
-            }
-            Err(other) => return Err(other.into()),
-        }
-    }
-
-    Ok(())
 }
 
 #[tokio::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod will;
 mod wire;
 
 pub use config::{Buffers, ConfigBuilder};
-pub use mqtt_client::{ConnectEvent, InboundPublish, Io, Op, Session};
+pub use mqtt_client::{ConnectEvent, Connection, InboundPublish, Io, Op, Session};
 pub use packets::Disconnect;
 pub use properties::{Properties, Property};
 pub use publication::{OwnedResponseTarget, Publication, ToPayload};

--- a/src/mqtt_client/mod.rs
+++ b/src/mqtt_client/mod.rs
@@ -1,7 +1,7 @@
 mod outbound;
 mod session;
 
-pub use session::Session;
+pub use session::{Connection, Session};
 
 use crate::{
     Properties, QoS, ResourceError, Retain,

--- a/src/mqtt_client/session/drive.rs
+++ b/src/mqtt_client/session/drive.rs
@@ -6,10 +6,10 @@ use crate::mqtt_client::outbound::{
     CONTROL_PACKET_LEN, ControlAction, OutboundStep, SendState, check_control_packet_size,
     serialize_control_packet, serialize_pubrel,
 };
-use crate::{Error, InboundPublish, debug, error, trace, warn};
+use crate::{Connection, Error, InboundPublish, debug, error, trace, warn};
 
+use super::Io;
 use super::state::ROUND_TRIP_TIMEOUT_MS;
-use super::{Io, Session};
 
 #[derive(Copy, Clone)]
 enum FlushedPacket {
@@ -62,15 +62,15 @@ pub(super) async fn fill_packet_reader<'buf, C: Io>(
     Ok(())
 }
 
-impl<'buf> Session<'buf> {
-    async fn drive_packet<IO: Io>(&mut self, io: &mut IO) -> Result<Progress, Error<IO::Error>> {
-        if !self.connected {
+impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
+    async fn drive_packet(&mut self) -> Result<Progress, Error<IO::Error>> {
+        if !self.live {
             return Err(Error::Disconnected);
         }
         let mut advanced = false;
         loop {
-            if self.packet_reader.packet_available() {
-                match self.process_received_packet::<IO>()? {
+            if self.session.packet_reader.packet_available() {
+                match self.process_received_packet()? {
                     Some(packet_length) => return Ok(Progress::Inbound(packet_length)),
                     None => {
                         advanced = true;
@@ -80,10 +80,10 @@ impl<'buf> Session<'buf> {
             }
 
             let now = Instant::now();
-            advanced |= self.service(io, now).await?;
+            advanced |= self.service(now).await?;
 
-            if self.packet_reader.packet_available() {
-                match self.process_received_packet::<IO>()? {
+            if self.session.packet_reader.packet_available() {
+                match self.process_received_packet()? {
                     Some(packet_length) => return Ok(Progress::Inbound(packet_length)),
                     None => {
                         advanced = true;
@@ -92,7 +92,7 @@ impl<'buf> Session<'buf> {
                 }
             }
 
-            if self.data.outbound.next_step().is_none() {
+            if self.session.data.outbound.next_step().is_none() {
                 return Ok(if advanced {
                     Progress::Advanced
                 } else {
@@ -114,11 +114,8 @@ impl<'buf> Session<'buf> {
     /// require waiting. Wall-clock bounds depend on the transport: a stalled write or flush may
     /// still keep this future pending until the transport errors or is cancelled. Cancel-safe if
     /// the underlying transport I/O futures are cancel-safe.
-    pub(super) async fn drive<IO: Io>(
-        &mut self,
-        io: &mut IO,
-    ) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        Ok(match self.drive_packet(io).await? {
+    pub async fn drive(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        Ok(match self.drive_packet().await? {
             Progress::Inbound(packet_length) => Some(self.decode_inbound_publish(packet_length)),
             Progress::Idle | Progress::Advanced => None,
         })
@@ -137,11 +134,8 @@ impl<'buf> Session<'buf> {
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe. Ordinary no-data must
     /// be represented by the transport future staying pending; `TimedOut` and `Interrupted` are
     /// treated as transport failure and disconnect the session.
-    pub(super) async fn poll<IO: Io>(
-        &mut self,
-        io: &mut IO,
-    ) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        match self.wait_for_progress(io).await? {
+    pub async fn poll(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        match self.wait_for_progress().await? {
             Progress::Inbound(packet_length) => {
                 Ok(Some(self.decode_inbound_publish(packet_length)))
             }
@@ -150,12 +144,9 @@ impl<'buf> Session<'buf> {
         }
     }
 
-    async fn wait_for_progress<IO: Io>(
-        &mut self,
-        io: &mut IO,
-    ) -> Result<Progress, Error<IO::Error>> {
+    async fn wait_for_progress(&mut self) -> Result<Progress, Error<IO::Error>> {
         loop {
-            match self.drive_packet(io).await? {
+            match self.drive_packet().await? {
                 Progress::Inbound(packet_length) => {
                     return Ok(Progress::Inbound(packet_length));
                 }
@@ -163,8 +154,8 @@ impl<'buf> Session<'buf> {
                 Progress::Idle => {}
             }
 
-            let deadline = self.runtime.next_deadline();
-            let read = self.read_packet(io);
+            let deadline = self.session.runtime.next_deadline();
+            let read = self.read_packet();
             match deadline {
                 Some(deadline) => match with_deadline(deadline, read).await {
                     Ok(Ok(())) => {}
@@ -180,12 +171,9 @@ impl<'buf> Session<'buf> {
     ///
     /// This is a convenience wrapper over [`poll`](Self::poll) that skips internal-only
     /// progress.
-    pub(super) async fn recv<IO: Io>(
-        &mut self,
-        io: &mut IO,
-    ) -> Result<InboundPublish<'_>, Error<IO::Error>> {
+    pub async fn recv(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
         loop {
-            match self.wait_for_progress(io).await? {
+            match self.wait_for_progress().await? {
                 Progress::Inbound(packet_length) => {
                     return Ok(self.decode_inbound_publish(packet_length));
                 }
@@ -197,109 +185,104 @@ impl<'buf> Session<'buf> {
         }
     }
 
-    pub(super) async fn service<IO: Io>(
-        &mut self,
-        io: &mut IO,
-        now: Instant,
-    ) -> Result<bool, Error<IO::Error>> {
-        if self
-            .runtime
+    pub(super) async fn service(&mut self, now: Instant) -> Result<bool, Error<IO::Error>> {
+        let runtime = &mut self.session.runtime;
+        if runtime
             .ping_timeout
             .map(|deadline| now >= deadline)
             .unwrap_or(false)
         {
             warn!(
                 "Keepalive ping timed out; disconnecting session next_ping={=?} ping_timeout={=?}",
-                self.runtime.next_ping, self.runtime.ping_timeout
+                runtime.next_ping, runtime.ping_timeout
             );
-            self.mark_disconnected();
+            self.handle_disconnect();
             return Err(Error::Disconnected);
         }
-        self.service_outbound_once(io, now).await
+        self.service_outbound_once(now).await
     }
 
     fn should_queue_pingreq(&self, now: Instant) -> bool {
-        self.runtime.ping_timeout.is_none()
+        self.session.runtime.ping_timeout.is_none()
             && self
+                .session
                 .runtime
                 .next_ping
                 .is_some_and(|deadline| now >= deadline)
-            && !self.data.outbound.has_pending_pingreq()
+            && !self.session.data.outbound.has_pending_pingreq()
     }
 
-    fn maybe_queue_pingreq<IO: Io>(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
+    fn maybe_queue_pingreq(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
         if self.should_queue_pingreq(now) {
-            check_control_packet_size(self.runtime.maximum_packet_size, ControlAction::PingReq)?;
-            self.data.outbound.queue_control(ControlAction::PingReq)?;
+            check_control_packet_size(
+                self.session.runtime.maximum_packet_size,
+                ControlAction::PingReq,
+            )?;
+            self.session
+                .data
+                .outbound
+                .queue_control(ControlAction::PingReq)?;
         }
         Ok(())
     }
 
-    pub(super) async fn read_packet<IO: Io>(
-        &mut self,
-        io: &mut IO,
-    ) -> Result<(), Error<IO::Error>> {
-        if let Err(err) = fill_packet_reader(&mut self.packet_reader, io).await {
+    pub(super) async fn read_packet(&mut self) -> Result<(), Error<IO::Error>> {
+        if !self.live {
+            return Err(Error::Disconnected);
+        }
+        if let Err(err) = fill_packet_reader(&mut self.session.packet_reader, &mut self.io).await {
             match &err {
                 Error::Transport(err) => warn!("Transport read failed: {}", err.kind()),
                 Error::Disconnected => warn!("Transport returned EOF; disconnecting session"),
                 _ => {}
             }
-            self.mark_disconnected();
+            self.handle_disconnect();
             return Err(err);
         }
         Ok(())
     }
 
-    async fn service_outbound_once<IO: Io>(
-        &mut self,
-        io: &mut IO,
-        now: Instant,
-    ) -> Result<bool, Error<IO::Error>> {
-        self.maybe_queue_pingreq::<IO>(now)?;
-        let Some(step) = self.data.outbound.next_step() else {
+    async fn service_outbound_once(&mut self, now: Instant) -> Result<bool, Error<IO::Error>> {
+        self.maybe_queue_pingreq(now)?;
+        let Some(step) = self.session.data.outbound.next_step() else {
             return Ok(false);
         };
-        self.perform_outbound_step(io, step, now).await
+        self.perform_outbound_step(step, now).await
     }
 
     fn complete_flush(&mut self, packet: FlushedPacket, now: Instant) {
+        let runtime = &mut self.session.runtime;
+        let data = &mut self.session.data;
         if matches!(packet, FlushedPacket::Control(ControlAction::PingReq)) {
-            self.runtime.ping_timeout = Some(now + Duration::from_millis(ROUND_TRIP_TIMEOUT_MS));
+            runtime.ping_timeout = Some(now + Duration::from_millis(ROUND_TRIP_TIMEOUT_MS));
         }
-        self.runtime.note_outbound_activity(now);
+        runtime.note_outbound_activity(now);
         let found = match packet {
-            FlushedPacket::Control(action) => self.data.outbound.flush_control(action),
-            FlushedPacket::Release(packet_id) => self.data.outbound.flush_release(packet_id),
-            FlushedPacket::Retained(packet_id) => self.data.outbound.flush_retained(packet_id),
+            FlushedPacket::Control(action) => data.outbound.flush_control(action),
+            FlushedPacket::Release(packet_id) => data.outbound.flush_release(packet_id),
+            FlushedPacket::Retained(packet_id) => data.outbound.flush_retained(packet_id),
         };
         debug_assert!(found, "completed outbound packet no longer tracked");
     }
 
     fn set_written(&mut self, packet: FlushedPacket, written: usize, len: usize) {
+        let out = &mut self.session.data.outbound;
         let found = match packet {
-            FlushedPacket::Control(action) => {
-                self.data.outbound.set_control_written(action, written, len)
-            }
-            FlushedPacket::Release(packet_id) => self
-                .data
-                .outbound
-                .set_release_written(packet_id, written, len),
-            FlushedPacket::Retained(packet_id) => self
-                .data
-                .outbound
-                .set_retained_written(packet_id, written, len),
+            FlushedPacket::Control(action) => out.set_control_written(action, written, len),
+            FlushedPacket::Release(packet_id) => out.set_release_written(packet_id, written, len),
+            FlushedPacket::Retained(packet_id) => out.set_retained_written(packet_id, written, len),
         };
         debug_assert!(found, "outbound packet no longer tracked");
     }
 
-    async fn perform_outbound_step<IO: Io>(
+    async fn perform_outbound_step(
         &mut self,
-        io: &mut IO,
         step: OutboundStep,
         now: Instant,
     ) -> Result<bool, Error<IO::Error>> {
         let mut small_buf = [0u8; CONTROL_PACKET_LEN];
+        let runtime = &mut self.session.runtime;
+        let data = &mut self.session.data;
         let prepared = match step {
             OutboundStep::Control(step) => match step.state {
                 SendState::Write { written } => {
@@ -307,14 +290,14 @@ impl<'buf> Session<'buf> {
                         "Driving control packet {} progress_from={=usize} control={=usize} retained={=usize} pending_release={=usize}",
                         step.action,
                         written,
-                        self.data.outbound.pending_control_len(),
-                        self.data.outbound.retained_len(),
-                        self.data.outbound.pending_release_len()
+                        data.outbound.pending_control_len(),
+                        data.outbound.retained_len(),
+                        data.outbound.pending_release_len()
                     );
                     let packet = serialize_control_packet(
                         &mut small_buf,
                         step.action,
-                        self.runtime.maximum_packet_size,
+                        runtime.maximum_packet_size,
                     )?;
                     PreparedStep::Write(WriteStep {
                         packet: FlushedPacket::Control(step.action),
@@ -335,15 +318,15 @@ impl<'buf> Session<'buf> {
                         "Driving PUBREL write packet_id={=u16} progress_from={=usize} control={=usize} retained={=usize} pending_release={=usize}",
                         step.packet_id,
                         written,
-                        self.data.outbound.pending_control_len(),
-                        self.data.outbound.retained_len(),
-                        self.data.outbound.pending_release_len()
+                        data.outbound.pending_control_len(),
+                        data.outbound.retained_len(),
+                        data.outbound.pending_release_len()
                     );
                     let packet = serialize_pubrel(
                         &mut small_buf,
                         step.packet_id,
                         step.reason,
-                        self.runtime.maximum_packet_size,
+                        runtime.maximum_packet_size,
                     )?;
                     PreparedStep::Write(WriteStep {
                         packet: FlushedPacket::Release(step.packet_id),
@@ -365,16 +348,16 @@ impl<'buf> Session<'buf> {
                         step.packet_id,
                         written,
                         step.len,
-                        self.data.outbound.pending_control_len(),
-                        self.data.outbound.used(),
-                        self.data.outbound.capacity(),
-                        self.data.outbound.retained_len(),
-                        self.data.outbound.pending_release_len()
+                        data.outbound.pending_control_len(),
+                        data.outbound.used(),
+                        data.outbound.capacity(),
+                        data.outbound.retained_len(),
+                        data.outbound.pending_release_len()
                     );
-                    self.runtime.require_packet_size(step.len)?;
+                    runtime.require_packet_size(step.len)?;
                     PreparedStep::Write(WriteStep {
                         packet: FlushedPacket::Retained(step.packet_id),
-                        bytes: self.data.outbound.retained_packet(step.offset, step.len),
+                        bytes: data.outbound.retained_packet(step.offset, step.len),
                         written,
                         len: step.len,
                     })
@@ -390,23 +373,26 @@ impl<'buf> Session<'buf> {
         let packet = match prepared {
             PreparedStep::Write(packet) => packet,
             PreparedStep::Flush(packet) => {
-                self.flush_current(io, packet, now).await?;
+                self.flush_current(packet, now).await?;
                 return Ok(true);
             }
             PreparedStep::Done => return Ok(false),
         };
 
+        if !self.live {
+            return Err(Error::Disconnected);
+        }
         let WriteStep {
             packet,
             bytes,
             written,
             len,
         } = packet;
-        let count = match write_current(io, &bytes[written..]).await {
+        let count = match write_current(&mut self.io, &bytes[written..]).await {
             Ok(count) => count,
             Err(Error::Transport(err)) => {
                 warn!("Outbound packet write failed: {}", err.kind());
-                self.mark_disconnected();
+                self.handle_disconnect();
                 return Err(Error::Transport(err));
             }
             Err(err) => return Err(err),
@@ -416,35 +402,34 @@ impl<'buf> Session<'buf> {
         if written < len {
             return Ok(true);
         }
-        self.flush_current(io, packet, now).await?;
+        self.flush_current(packet, now).await?;
         Ok(true)
     }
 
-    async fn flush_current<IO: Io>(
+    async fn flush_current(
         &mut self,
-        io: &mut IO,
         packet: FlushedPacket,
         now: Instant,
     ) -> Result<(), Error<IO::Error>> {
-        if let Err(err) = io.flush().await {
+        if !self.live {
+            return Err(Error::Disconnected);
+        }
+        if let Err(err) = self.io.flush().await {
             warn!("Outbound packet flush failed: {}", err.kind());
-            self.mark_disconnected();
+            self.handle_disconnect();
             return Err(Error::Transport(err));
         }
         self.complete_flush(packet, now);
         Ok(())
     }
 
-    pub(super) async fn flush_outbound<IO: Io>(
-        &mut self,
-        io: &mut IO,
-    ) -> Result<(), Error<IO::Error>> {
+    pub(super) async fn flush_outbound(&mut self) -> Result<(), Error<IO::Error>> {
         loop {
-            self.maybe_queue_pingreq::<IO>(Instant::now())?;
-            let Some(step) = self.data.outbound.next_step() else {
+            self.maybe_queue_pingreq(Instant::now())?;
+            let Some(step) = self.session.data.outbound.next_step() else {
                 return Ok(());
             };
-            self.perform_outbound_step(io, step, Instant::now()).await?;
+            self.perform_outbound_step(step, Instant::now()).await?;
         }
     }
 }

--- a/src/mqtt_client/session/drive.rs
+++ b/src/mqtt_client/session/drive.rs
@@ -62,19 +62,15 @@ pub(super) async fn fill_packet_reader<'buf, C: Io>(
     Ok(())
 }
 
-impl<'buf, IO> Session<'buf, IO>
-where
-    IO: Io,
-{
-    async fn drive_packet(&mut self) -> Result<Progress, Error<IO::Error>> {
-        if self.connection.is_none() {
+impl<'buf> Session<'buf> {
+    async fn drive_packet<IO: Io>(&mut self, io: &mut IO) -> Result<Progress, Error<IO::Error>> {
+        if !self.connected {
             return Err(Error::Disconnected);
         }
-
         let mut advanced = false;
         loop {
             if self.packet_reader.packet_available() {
-                match self.process_received_packet()? {
+                match self.process_received_packet::<IO>()? {
                     Some(packet_length) => return Ok(Progress::Inbound(packet_length)),
                     None => {
                         advanced = true;
@@ -84,10 +80,10 @@ where
             }
 
             let now = Instant::now();
-            advanced |= self.service(now).await?;
+            advanced |= self.service(io, now).await?;
 
             if self.packet_reader.packet_available() {
-                match self.process_received_packet()? {
+                match self.process_received_packet::<IO>()? {
                     Some(packet_length) => return Ok(Progress::Inbound(packet_length)),
                     None => {
                         advanced = true;
@@ -118,8 +114,11 @@ where
     /// require waiting. Wall-clock bounds depend on the transport: a stalled write or flush may
     /// still keep this future pending until the transport errors or is cancelled. Cancel-safe if
     /// the underlying transport I/O futures are cancel-safe.
-    pub async fn drive(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        Ok(match self.drive_packet().await? {
+    pub(super) async fn drive<IO: Io>(
+        &mut self,
+        io: &mut IO,
+    ) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        Ok(match self.drive_packet(io).await? {
             Progress::Inbound(packet_length) => Some(self.decode_inbound_publish(packet_length)),
             Progress::Idle | Progress::Advanced => None,
         })
@@ -138,8 +137,11 @@ where
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe. Ordinary no-data must
     /// be represented by the transport future staying pending; `TimedOut` and `Interrupted` are
     /// treated as transport failure and disconnect the session.
-    pub async fn poll(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        match self.wait_for_progress().await? {
+    pub(super) async fn poll<IO: Io>(
+        &mut self,
+        io: &mut IO,
+    ) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        match self.wait_for_progress(io).await? {
             Progress::Inbound(packet_length) => {
                 Ok(Some(self.decode_inbound_publish(packet_length)))
             }
@@ -148,9 +150,12 @@ where
         }
     }
 
-    async fn wait_for_progress(&mut self) -> Result<Progress, Error<IO::Error>> {
+    async fn wait_for_progress<IO: Io>(
+        &mut self,
+        io: &mut IO,
+    ) -> Result<Progress, Error<IO::Error>> {
         loop {
-            match self.drive_packet().await? {
+            match self.drive_packet(io).await? {
                 Progress::Inbound(packet_length) => {
                     return Ok(Progress::Inbound(packet_length));
                 }
@@ -159,7 +164,7 @@ where
             }
 
             let deadline = self.runtime.next_deadline();
-            let read = self.read_packet();
+            let read = self.read_packet(io);
             match deadline {
                 Some(deadline) => match with_deadline(deadline, read).await {
                     Ok(Ok(())) => {}
@@ -175,9 +180,12 @@ where
     ///
     /// This is a convenience wrapper over [`poll`](Self::poll) that skips internal-only
     /// progress.
-    pub async fn recv(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
+    pub(super) async fn recv<IO: Io>(
+        &mut self,
+        io: &mut IO,
+    ) -> Result<InboundPublish<'_>, Error<IO::Error>> {
         loop {
-            match self.wait_for_progress().await? {
+            match self.wait_for_progress(io).await? {
                 Progress::Inbound(packet_length) => {
                     return Ok(self.decode_inbound_publish(packet_length));
                 }
@@ -189,7 +197,11 @@ where
         }
     }
 
-    pub(super) async fn service(&mut self, now: Instant) -> Result<bool, Error<IO::Error>> {
+    pub(super) async fn service<IO: Io>(
+        &mut self,
+        io: &mut IO,
+        now: Instant,
+    ) -> Result<bool, Error<IO::Error>> {
         if self
             .runtime
             .ping_timeout
@@ -200,10 +212,10 @@ where
                 "Keepalive ping timed out; disconnecting session next_ping={=?} ping_timeout={=?}",
                 self.runtime.next_ping, self.runtime.ping_timeout
             );
-            self.handle_disconnect();
+            self.mark_disconnected();
             return Err(Error::Disconnected);
         }
-        self.service_outbound_once(now).await
+        self.service_outbound_once(io, now).await
     }
 
     fn should_queue_pingreq(&self, now: Instant) -> bool {
@@ -215,7 +227,7 @@ where
             && !self.data.outbound.has_pending_pingreq()
     }
 
-    fn maybe_queue_pingreq(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
+    fn maybe_queue_pingreq<IO: Io>(&mut self, now: Instant) -> Result<(), Error<IO::Error>> {
         if self.should_queue_pingreq(now) {
             check_control_packet_size(self.runtime.maximum_packet_size, ControlAction::PingReq)?;
             self.data.outbound.queue_control(ControlAction::PingReq)?;
@@ -223,28 +235,32 @@ where
         Ok(())
     }
 
-    pub(super) async fn read_packet(&mut self) -> Result<(), Error<IO::Error>> {
-        let Some(connection) = self.connection.as_mut() else {
-            return Err(Error::Disconnected);
-        };
-        if let Err(err) = fill_packet_reader(&mut self.packet_reader, connection).await {
+    pub(super) async fn read_packet<IO: Io>(
+        &mut self,
+        io: &mut IO,
+    ) -> Result<(), Error<IO::Error>> {
+        if let Err(err) = fill_packet_reader(&mut self.packet_reader, io).await {
             match &err {
                 Error::Transport(err) => warn!("Transport read failed: {}", err.kind()),
                 Error::Disconnected => warn!("Transport returned EOF; disconnecting session"),
                 _ => {}
             }
-            self.handle_disconnect();
+            self.mark_disconnected();
             return Err(err);
         }
         Ok(())
     }
 
-    async fn service_outbound_once(&mut self, now: Instant) -> Result<bool, Error<IO::Error>> {
-        self.maybe_queue_pingreq(now)?;
+    async fn service_outbound_once<IO: Io>(
+        &mut self,
+        io: &mut IO,
+        now: Instant,
+    ) -> Result<bool, Error<IO::Error>> {
+        self.maybe_queue_pingreq::<IO>(now)?;
         let Some(step) = self.data.outbound.next_step() else {
             return Ok(false);
         };
-        self.perform_outbound_step(step, now).await
+        self.perform_outbound_step(io, step, now).await
     }
 
     fn complete_flush(&mut self, packet: FlushedPacket, now: Instant) {
@@ -277,8 +293,9 @@ where
         debug_assert!(found, "outbound packet no longer tracked");
     }
 
-    async fn perform_outbound_step(
+    async fn perform_outbound_step<IO: Io>(
         &mut self,
+        io: &mut IO,
         step: OutboundStep,
         now: Instant,
     ) -> Result<bool, Error<IO::Error>> {
@@ -373,7 +390,7 @@ where
         let packet = match prepared {
             PreparedStep::Write(packet) => packet,
             PreparedStep::Flush(packet) => {
-                self.flush_current(packet, now).await?;
+                self.flush_current(io, packet, now).await?;
                 return Ok(true);
             }
             PreparedStep::Done => return Ok(false),
@@ -385,15 +402,11 @@ where
             written,
             len,
         } = packet;
-        let count = {
-            let connection = self.connection.as_mut().ok_or(Error::Disconnected)?;
-            write_current(connection, &bytes[written..]).await
-        };
-        let count = match count {
+        let count = match write_current(io, &bytes[written..]).await {
             Ok(count) => count,
             Err(Error::Transport(err)) => {
                 warn!("Outbound packet write failed: {}", err.kind());
-                self.handle_disconnect();
+                self.mark_disconnected();
                 return Err(Error::Transport(err));
             }
             Err(err) => return Err(err),
@@ -403,50 +416,35 @@ where
         if written < len {
             return Ok(true);
         }
-        self.flush_current(packet, now).await?;
+        self.flush_current(io, packet, now).await?;
         Ok(true)
     }
 
-    async fn flush_current(
+    async fn flush_current<IO: Io>(
         &mut self,
+        io: &mut IO,
         packet: FlushedPacket,
         now: Instant,
     ) -> Result<(), Error<IO::Error>> {
-        let res = {
-            let connection = self.connection.as_mut().ok_or(Error::Disconnected)?;
-            connection.flush().await
-        };
-        if let Err(err) = res {
+        if let Err(err) = io.flush().await {
             warn!("Outbound packet flush failed: {}", err.kind());
-            self.handle_disconnect();
+            self.mark_disconnected();
             return Err(Error::Transport(err));
         }
         self.complete_flush(packet, now);
         Ok(())
     }
 
-    pub(super) fn handle_disconnect(&mut self) {
-        debug!(
-            "Resetting local session transport state and arming replay if needed control={=usize} tx_used={=usize} tx_capacity={=usize} retained={=usize} pending_release={=usize}",
-            self.data.outbound.pending_control_len(),
-            self.data.outbound.used(),
-            self.data.outbound.capacity(),
-            self.data.outbound.retained_len(),
-            self.data.outbound.pending_release_len()
-        );
-        self.connection = None;
-        self.data.outbound.arm_replay();
-        self.runtime.reset_transport();
-        self.packet_reader.reset();
-    }
-
-    pub(super) async fn flush_outbound(&mut self) -> Result<(), Error<IO::Error>> {
+    pub(super) async fn flush_outbound<IO: Io>(
+        &mut self,
+        io: &mut IO,
+    ) -> Result<(), Error<IO::Error>> {
         loop {
-            self.maybe_queue_pingreq(Instant::now())?;
+            self.maybe_queue_pingreq::<IO>(Instant::now())?;
             let Some(step) = self.data.outbound.next_step() else {
                 return Ok(());
             };
-            self.perform_outbound_step(step, Instant::now()).await?;
+            self.perform_outbound_step(io, step, Instant::now()).await?;
         }
     }
 }

--- a/src/mqtt_client/session/handshake.rs
+++ b/src/mqtt_client/session/handshake.rs
@@ -29,16 +29,32 @@ impl<'buf> Session<'buf> {
         &mut self,
         mut io: IO,
     ) -> Result<Connection<'_, 'buf, IO>, Error<IO::Error>> {
+        // We are not guaranteed that any of those 3 calls have been made after
+        // the previous `connect` call.
         self.packet_reader.reset();
         self.runtime.reset_transport();
         self.data.outbound.arm_replay();
         let event = self.connect_handshake(&mut io).await?;
-        self.connected = true;
         Ok(Connection {
             session: self,
             io,
             event,
+            live: true,
         })
+    }
+
+    pub(super) fn handle_disconnect(&mut self) {
+        debug!(
+            "Resetting local session transport state and arming replay if needed control={=usize} tx_used={=usize} tx_capacity={=usize} retained={=usize} pending_release={=usize}",
+            self.data.outbound.pending_control_len(),
+            self.data.outbound.used(),
+            self.data.outbound.capacity(),
+            self.data.outbound.retained_len(),
+            self.data.outbound.pending_release_len()
+        );
+        self.data.outbound.arm_replay();
+        self.runtime.reset_transport();
+        self.packet_reader.reset();
     }
 
     async fn connect_handshake<IO: Io>(
@@ -91,6 +107,7 @@ impl<'buf> Session<'buf> {
                 Error::Disconnected => warn!("Transport returned EOF during CONNECT"),
                 _ => {}
             }
+            self.handle_disconnect();
             return Err(err);
         }
 
@@ -98,6 +115,7 @@ impl<'buf> Session<'buf> {
             Ok(packet) => packet,
             Err(err) => {
                 warn!("Failed to decode inbound packet: {}", err);
+                self.handle_disconnect();
                 return Err(err.into());
             }
         };
@@ -108,9 +126,11 @@ impl<'buf> Session<'buf> {
                     "Received broker DISCONNECT during CONNECT reason={}",
                     disconnect.reason_code()
                 );
+                self.handle_disconnect();
                 return Err(Error::Disconnected);
             }
             _ => {
+                self.handle_disconnect();
                 return Err(Error::Peer(PeerError::InvalidPacket));
             }
         };
@@ -161,6 +181,7 @@ impl<'buf> Session<'buf> {
             Ok(())
         })();
         if let Err(err) = property_result {
+            self.handle_disconnect();
             return Err(Error::Peer(err));
         }
 

--- a/src/mqtt_client/session/handshake.rs
+++ b/src/mqtt_client/session/handshake.rs
@@ -10,31 +10,38 @@ use crate::properties::Properties;
 use crate::wire::Utf8String;
 use crate::{Error, PeerError, Property, QoS, debug, info, warn};
 
-use super::{Io, Session, drive::fill_packet_reader};
+use super::{Connection, Io, Session, drive::fill_packet_reader};
 
-impl<'buf, IO> Session<'buf, IO>
-where
-    IO: Io,
-{
+impl<'buf> Session<'buf> {
     /// Establish or resume the MQTT session on a newly supplied transport.
     ///
-    /// The session takes ownership of `io` for the lifetime of the connected session and drops it
-    /// again on disconnect or connection failure. If cancelled during the handshake, `io` is
-    /// dropped and a later `connect()` restarts from clean transport-local state.
-    pub async fn connect(&mut self, mut io: IO) -> Result<ConnectEvent, Error<IO::Error>> {
-        if self.connection.is_some() {
-            return Err(Error::NotReady);
-        }
+    /// On success the returned [`Connection`] takes ownership of `io` for the lifetime of the
+    /// connected session and borrows this session; all network operations are driven through it.
+    /// On handshake failure (or cancellation) `io` is dropped and the session is left disconnected.
+    ///
+    /// All state carried across reconnects (in-flight QoS replay, keepalive timers, the inbound
+    /// packet reader) is reset here, at the start of every `connect`, so it does not matter how a
+    /// previous [`Connection`] ended — dropped, `mem::forget`-ed, or errored. A previous handle that
+    /// was merely dropped did not send a `DISCONNECT`; if the broker still holds the session it is
+    /// resumed here (`CONNECT` `clean_start=false`, yielding [`ConnectEvent::Reconnected`]),
+    /// otherwise a fresh session is started ([`ConnectEvent::Connected`]).
+    pub async fn connect<IO: Io>(
+        &mut self,
+        mut io: IO,
+    ) -> Result<Connection<'_, 'buf, IO>, Error<IO::Error>> {
         self.packet_reader.reset();
         self.runtime.reset_transport();
-        let result = self.connect_handshake(&mut io).await;
-        if result.is_ok() {
-            self.connection = Some(io);
-        }
-        result
+        self.data.outbound.arm_replay();
+        let event = self.connect_handshake(&mut io).await?;
+        self.connected = true;
+        Ok(Connection {
+            session: self,
+            io,
+            event,
+        })
     }
 
-    async fn connect_handshake(
+    async fn connect_handshake<IO: Io>(
         &mut self,
         connection: &mut IO,
     ) -> Result<ConnectEvent, Error<IO::Error>> {
@@ -84,7 +91,6 @@ where
                 Error::Disconnected => warn!("Transport returned EOF during CONNECT"),
                 _ => {}
             }
-            self.handle_disconnect();
             return Err(err);
         }
 
@@ -92,7 +98,6 @@ where
             Ok(packet) => packet,
             Err(err) => {
                 warn!("Failed to decode inbound packet: {}", err);
-                self.handle_disconnect();
                 return Err(err.into());
             }
         };
@@ -103,18 +108,15 @@ where
                     "Received broker DISCONNECT during CONNECT reason={}",
                     disconnect.reason_code()
                 );
-                self.handle_disconnect();
                 return Err(Error::Disconnected);
             }
             _ => {
-                self.handle_disconnect();
                 return Err(Error::Peer(PeerError::InvalidPacket));
             }
         };
 
         if let Err(err) = ack.reason_code.as_result() {
             warn!("Broker rejected CONNECT with reason {}", ack.reason_code);
-            self.handle_disconnect();
             return Err(Error::Peer(err));
         }
 
@@ -159,7 +161,6 @@ where
             Ok(())
         })();
         if let Err(err) = property_result {
-            self.handle_disconnect();
             return Err(Error::Peer(err));
         }
 

--- a/src/mqtt_client/session/inbound.rs
+++ b/src/mqtt_client/session/inbound.rs
@@ -200,11 +200,10 @@ impl<'a> SessionData<'a> {
     }
 }
 
-impl<'buf, IO> Session<'buf, IO>
-where
-    IO: Io,
-{
-    pub(super) fn process_received_packet(&mut self) -> Result<Option<usize>, Error<IO::Error>> {
+impl<'buf> Session<'buf> {
+    pub(super) fn process_received_packet<IO: Io>(
+        &mut self,
+    ) -> Result<Option<usize>, Error<IO::Error>> {
         if !self.packet_reader.packet_available() {
             return Ok(None);
         }
@@ -213,7 +212,7 @@ where
             Ok(packet) => packet,
             Err(err) => {
                 warn!("Failed to decode inbound packet: {}", err);
-                self.handle_disconnect();
+                self.mark_disconnected();
                 return Err(err.into());
             }
         };
@@ -222,17 +221,17 @@ where
             Ok(false) => Ok(None),
             Err(Error::Disconnected) => {
                 warn!("Disconnecting session after broker DISCONNECT");
-                self.handle_disconnect();
+                self.mark_disconnected();
                 Err(Error::Disconnected)
             }
             Err(Error::Peer(PeerError::InvalidPacket)) => {
                 warn!("Disconnecting session after packet handling error");
-                self.handle_disconnect();
+                self.mark_disconnected();
                 Err(Error::Peer(PeerError::InvalidPacket))
             }
             Err(Error::Resource(ResourceError::PacketTooLarge)) => {
                 warn!("Disconnecting session after packet handling error");
-                self.handle_disconnect();
+                self.mark_disconnected();
                 Err(Error::Resource(ResourceError::PacketTooLarge))
             }
             Err(Error::Peer(err)) => Err(Error::Peer(err)),

--- a/src/mqtt_client/session/inbound.rs
+++ b/src/mqtt_client/session/inbound.rs
@@ -3,12 +3,11 @@ use core::convert::Infallible;
 use crate::de::ReceivedPacket;
 use crate::mqtt_client::outbound::{ControlAction, check_control_packet_size, check_pubrel_size};
 use crate::{
-    Error, InboundPublish, PeerError, ProtocolError, QoS, ReasonCode, ResourceError, debug, info,
-    trace, warn,
+    Connection, Error, InboundPublish, Io, PeerError, ProtocolError, QoS, ReasonCode,
+    ResourceError, debug, info, trace, warn,
 };
 
 use super::state::{RuntimeState, SessionData};
-use super::{Io, Session};
 
 impl<'a> SessionData<'a> {
     pub(super) fn handle_packet(
@@ -200,38 +199,40 @@ impl<'a> SessionData<'a> {
     }
 }
 
-impl<'buf> Session<'buf> {
-    pub(super) fn process_received_packet<IO: Io>(
-        &mut self,
-    ) -> Result<Option<usize>, Error<IO::Error>> {
-        if !self.packet_reader.packet_available() {
+impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
+    pub(super) fn process_received_packet(&mut self) -> Result<Option<usize>, Error<IO::Error>> {
+        if !self.session.packet_reader.packet_available() {
             return Ok(None);
         }
 
-        let (packet_length, packet) = match self.packet_reader.take_packet() {
+        let (packet_length, packet) = match self.session.packet_reader.take_packet() {
             Ok(packet) => packet,
             Err(err) => {
                 warn!("Failed to decode inbound packet: {}", err);
-                self.mark_disconnected();
+                self.handle_disconnect();
                 return Err(err.into());
             }
         };
-        match self.data.handle_packet(&mut self.runtime, packet) {
+        match self
+            .session
+            .data
+            .handle_packet(&mut self.session.runtime, packet)
+        {
             Ok(true) => Ok(Some(packet_length)),
             Ok(false) => Ok(None),
             Err(Error::Disconnected) => {
                 warn!("Disconnecting session after broker DISCONNECT");
-                self.mark_disconnected();
+                self.handle_disconnect();
                 Err(Error::Disconnected)
             }
             Err(Error::Peer(PeerError::InvalidPacket)) => {
                 warn!("Disconnecting session after packet handling error");
-                self.mark_disconnected();
+                self.handle_disconnect();
                 Err(Error::Peer(PeerError::InvalidPacket))
             }
             Err(Error::Resource(ResourceError::PacketTooLarge)) => {
                 warn!("Disconnecting session after packet handling error");
-                self.mark_disconnected();
+                self.handle_disconnect();
                 Err(Error::Resource(ResourceError::PacketTooLarge))
             }
             Err(Error::Peer(err)) => Err(Error::Peer(err)),
@@ -244,9 +245,9 @@ impl<'buf> Session<'buf> {
     }
 
     pub(super) fn decode_inbound_publish(&self, packet_length: usize) -> InboundPublish<'_> {
-        let ReceivedPacket::Publish(info) =
-            ReceivedPacket::from_buffer(&self.packet_reader.buffer[..packet_length])
-                .expect("inbound packet must remain decodable")
+        let buffer = &self.session.packet_reader.buffer[..];
+        let ReceivedPacket::Publish(info) = ReceivedPacket::from_buffer(&buffer[..packet_length])
+            .expect("inbound packet must remain decodable")
         else {
             unreachable!("inbound event must be a PUBLISH");
         };

--- a/src/mqtt_client/session/mod.rs
+++ b/src/mqtt_client/session/mod.rs
@@ -163,7 +163,7 @@ impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
         self.session
     }
 
-    /// Return whether the session is connected and currently has the local capacity to attempt a
+    /// Return whether the transport is connected and the session currently has the local capacity to attempt a
     /// publish at the requested QoS.
     pub fn can_publish(&self, qos: QoS) -> bool {
         self.live && self.session.can_publish(qos)

--- a/src/mqtt_client/session/mod.rs
+++ b/src/mqtt_client/session/mod.rs
@@ -81,7 +81,7 @@ impl<'buf> Session<'buf> {
         self.data.outbound.capacity()
     }
 
-    /// Return whether the session is connected and currently has the local capacity to attempt a
+    /// Return whether the session currently has the local capacity to attempt a
     /// publish at the requested QoS.
     fn can_publish(&self, qos: QoS) -> bool {
         if qos == QoS::AtMostOnce {

--- a/src/mqtt_client/session/mod.rs
+++ b/src/mqtt_client/session/mod.rs
@@ -8,12 +8,14 @@ mod state;
 mod tests;
 
 use crate::de::PacketReader;
+use crate::packets::Disconnect;
+use crate::publication::{Publication, ToPayload};
 use crate::ser::MAX_FIXED_HEADER_SIZE;
-use crate::types::Auth;
-use crate::{ConfigBuilder, Op, QoS, Will};
+use crate::types::{Auth, TopicFilter};
+use crate::{ConfigBuilder, Error, InboundPublish, Op, Property, PubError, QoS, Will};
 use heapless::String;
 
-use super::{Io, OpKind, OpStatus};
+use super::{ConnectEvent, Io, OpKind, OpStatus};
 
 use state::{RuntimeState, SessionData};
 
@@ -34,8 +36,7 @@ use state::{RuntimeState, SessionData};
 /// disconnected; the next `connect()` retries from clean transport-local state. QoS 0
 /// [`publish`](Self::publish) is not cancel-safe because it bypasses retained outbound state and
 /// writes directly from temporary TX scratch space.
-pub struct Session<'buf, IO> {
-    connection: Option<IO>,
+pub struct Session<'buf> {
     client_id: String<64>,
     packet_reader: PacketReader<'buf>,
     data: SessionData<'buf>,
@@ -44,12 +45,15 @@ pub struct Session<'buf, IO> {
     auth: Option<Auth<'buf>>,
     session_expiry_interval: u32,
     downgrade_qos: bool,
+    /// Whether the transport currently owned by an outstanding [`Connection`] is still usable.
+    /// Set true by a successful [`connect`](Self::connect) and latched false the moment any
+    /// operation observes a fatal transport- or protocol-level disconnect. State carried to the
+    /// next connection is reset in `connect`, not here, so the latch does not depend on the
+    /// handle's `Drop` running.
+    connected: bool,
 }
 
-impl<'buf, IO> Session<'buf, IO>
-where
-    IO: Io,
-{
+impl<'buf> Session<'buf> {
     /// Construct a session from a setup builder.
     pub fn new(config: ConfigBuilder<'buf>) -> Self {
         let (
@@ -64,7 +68,6 @@ where
         let (rx, tx) = buffers.into_parts();
 
         Self {
-            connection: None,
             client_id,
             packet_reader: PacketReader::new(rx),
             data: SessionData::new(tx),
@@ -73,12 +76,15 @@ where
             auth,
             session_expiry_interval,
             downgrade_qos,
+            connected: false,
         }
     }
 
-    /// Return whether the MQTT session is currently established.
-    pub fn is_connected(&self) -> bool {
-        self.connection.is_some()
+    /// Latch the current transport as disconnected. Called at every site that observes a fatal
+    /// transport- or protocol-level failure. Only flips the liveness flag; state needed for the
+    /// next connection is reset in `connect`.
+    pub(super) fn mark_disconnected(&mut self) {
+        self.connected = false;
     }
 
     /// Return the maximum inbound MQTT packet size accepted by this session.
@@ -91,10 +97,10 @@ where
         self.data.outbound.capacity()
     }
 
-    /// Return whether the session currently has the local capacity to attempt a
+    /// Return whether the session is connected and currently has the local capacity to attempt a
     /// publish at the requested QoS.
     pub fn can_publish(&self, qos: QoS) -> bool {
-        self.connection.is_some()
+        self.connected
             && if qos == QoS::AtMostOnce {
                 self.data.outbound.scratch_len() >= MAX_FIXED_HEADER_SIZE
             } else {
@@ -143,5 +149,132 @@ where
     /// Return whether the local session state that could complete this operation was discarded.
     pub fn is_invalidated(&self, op: &Op) -> bool {
         self.status(op) == OpStatus::Invalidated
+    }
+}
+
+/// A live MQTT connection over a transport `IO`, returned by
+/// [`Session::connect`](Session::connect).
+///
+/// The handle owns the transport and borrows the [`Session`] for the duration of the connection.
+/// All network operations (`drive`, `poll`, `recv`, `publish`, `subscribe`, `unsubscribe`,
+/// `disconnect`) live here; session-state queries (`is_pending`, `is_complete`, `can_publish`, …)
+/// are reachable through the [`Deref`](core::ops::Deref) to the underlying [`Session`].
+///
+/// Dropping (or [`mem::forget`](core::mem::forget)-ing) the handle releases the transport and the
+/// session borrow; the same `Session` can then be reconnected with a fresh transport — possibly of
+/// a different `IO` type or buffer lifetime. State needed across reconnects (in-flight QoS replay,
+/// keepalive timers, the inbound packet reader) is reset at the start of the next
+/// [`Session::connect`](Session::connect), so correctness does not depend on this handle's `Drop`
+/// running.
+///
+/// Note that dropping or forgetting the handle is an *ungraceful* MQTT close: **no `DISCONNECT`
+/// packet is sent** (a sync `Drop` cannot perform the async write), so the broker sees an abnormal
+/// disconnect and will publish the configured Will, if any. Whether the underlying transport is
+/// actually closed is up to the `IO`'s own `Drop`. For a clean shutdown — `DISCONNECT` sent, Will
+/// suppressed — call [`disconnect`](Self::disconnect) (or [`disconnect_with`](Self::disconnect_with))
+/// before dropping. Reconnecting afterwards with [`Session::connect`](Session::connect) resumes the
+/// broker session via `CONNECT` `clean_start=false`; see [`ConnectEvent`](crate::ConnectEvent).
+pub struct Connection<'a, 'buf, IO> {
+    pub(super) session: &'a mut Session<'buf>,
+    pub(super) io: IO,
+    pub(super) event: ConnectEvent,
+}
+
+impl<'buf, IO> core::ops::Deref for Connection<'_, 'buf, IO> {
+    type Target = Session<'buf>;
+
+    fn deref(&self) -> &Self::Target {
+        self.session
+    }
+}
+
+impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
+    /// Whether this connection started a fresh broker session or resumed an existing one.
+    pub fn connect_event(&self) -> ConnectEvent {
+        self.event
+    }
+
+    /// Whether the connection is still live.
+    ///
+    /// Becomes `false` once any operation on this handle has observed a transport- or
+    /// protocol-level disconnect (broker `DISCONNECT`, transport error, keepalive timeout, fatal
+    /// protocol violation) or after a graceful [`disconnect`](Self::disconnect). Once `false`,
+    /// further operations fail fast with [`Error::Disconnected`](crate::Error::Disconnected)
+    /// instead of driving the dead transport; drop the handle and `connect` again to recover.
+    pub fn is_connected(&self) -> bool {
+        self.session.connected
+    }
+
+    /// See [`Session`] docs: advance local session state cooperatively without waiting on new
+    /// inbound reads or future deadlines.
+    pub async fn drive(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        self.session.drive(&mut self.io).await
+    }
+
+    /// Wait until any session progress happens or the session disconnects.
+    pub async fn poll(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
+        self.session.poll(&mut self.io).await
+    }
+
+    /// Wait until the next inbound publish arrives.
+    pub async fn recv(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
+        self.session.recv(&mut self.io).await
+    }
+
+    /// Send a `SUBSCRIBE`.
+    pub async fn subscribe(
+        &mut self,
+        topics: &[TopicFilter<'_>],
+        properties: &[Property<'_>],
+    ) -> Result<Op, Error<IO::Error>> {
+        self.session
+            .subscribe(&mut self.io, topics, properties)
+            .await
+    }
+
+    /// Send an `UNSUBSCRIBE`.
+    pub async fn unsubscribe(
+        &mut self,
+        topics: &[&str],
+        properties: &[Property<'_>],
+    ) -> Result<Op, Error<IO::Error>> {
+        self.session
+            .unsubscribe(&mut self.io, topics, properties)
+            .await
+    }
+
+    /// Send a `PUBLISH`.
+    pub async fn publish<P>(
+        &mut self,
+        publication: Publication<'_, P>,
+    ) -> Result<Option<Op>, PubError<P::Error, IO::Error>>
+    where
+        P: ToPayload,
+    {
+        self.session.publish(&mut self.io, publication).await
+    }
+
+    /// Gracefully close the transport with `DISCONNECT`.
+    ///
+    /// This is the graceful counterpart to simply dropping the handle: it sends the MQTT
+    /// `DISCONNECT` so the broker closes cleanly and suppresses the Will. Just dropping (or
+    /// [`mem::forget`](core::mem::forget)-ing) the handle skips this and is treated by the broker
+    /// as an abnormal disconnect.
+    ///
+    /// Takes `&mut self` rather than consuming the handle, so a cancelled disconnect can be
+    /// retried. After a successful disconnect the handle's transport is dead; drop it (or
+    /// `mem::forget` it) to release the session for a fresh `connect`.
+    pub async fn disconnect(&mut self) -> Result<(), Error<IO::Error>> {
+        self.session
+            .disconnect_with(&mut self.io, Disconnect::success())
+            .await
+    }
+
+    /// Close the transport with a caller-specified `DISCONNECT`.
+    pub async fn disconnect_with(
+        &mut self,
+        disconnect: Disconnect<'_>,
+    ) -> Result<(), Error<IO::Error>> {
+        self.session.disconnect_with(&mut self.io, disconnect).await
     }
 }

--- a/src/mqtt_client/session/mod.rs
+++ b/src/mqtt_client/session/mod.rs
@@ -8,11 +8,9 @@ mod state;
 mod tests;
 
 use crate::de::PacketReader;
-use crate::packets::Disconnect;
-use crate::publication::{Publication, ToPayload};
 use crate::ser::MAX_FIXED_HEADER_SIZE;
-use crate::types::{Auth, TopicFilter};
-use crate::{ConfigBuilder, Error, InboundPublish, Op, Property, PubError, QoS, Will};
+use crate::types::Auth;
+use crate::{ConfigBuilder, Op, QoS, Will};
 use heapless::String;
 
 use super::{ConnectEvent, Io, OpKind, OpStatus};
@@ -45,12 +43,6 @@ pub struct Session<'buf> {
     auth: Option<Auth<'buf>>,
     session_expiry_interval: u32,
     downgrade_qos: bool,
-    /// Whether the transport currently owned by an outstanding [`Connection`] is still usable.
-    /// Set true by a successful [`connect`](Self::connect) and latched false the moment any
-    /// operation observes a fatal transport- or protocol-level disconnect. State carried to the
-    /// next connection is reset in `connect`, not here, so the latch does not depend on the
-    /// handle's `Drop` running.
-    connected: bool,
 }
 
 impl<'buf> Session<'buf> {
@@ -76,15 +68,7 @@ impl<'buf> Session<'buf> {
             auth,
             session_expiry_interval,
             downgrade_qos,
-            connected: false,
         }
-    }
-
-    /// Latch the current transport as disconnected. Called at every site that observes a fatal
-    /// transport- or protocol-level failure. Only flips the liveness flag; state needed for the
-    /// next connection is reset in `connect`.
-    pub(super) fn mark_disconnected(&mut self) {
-        self.connected = false;
     }
 
     /// Return the maximum inbound MQTT packet size accepted by this session.
@@ -99,13 +83,12 @@ impl<'buf> Session<'buf> {
 
     /// Return whether the session is connected and currently has the local capacity to attempt a
     /// publish at the requested QoS.
-    pub fn can_publish(&self, qos: QoS) -> bool {
-        self.connected
-            && if qos == QoS::AtMostOnce {
-                self.data.outbound.scratch_len() >= MAX_FIXED_HEADER_SIZE
-            } else {
-                self.runtime.send_quota != 0 && self.data.outbound.can_retain()
-            }
+    fn can_publish(&self, qos: QoS) -> bool {
+        if qos == QoS::AtMostOnce {
+            self.data.outbound.scratch_len() >= MAX_FIXED_HEADER_SIZE
+        } else {
+            self.runtime.send_quota != 0 && self.data.outbound.can_retain()
+        }
     }
 
     /// Return whether the session has no in-flight retained MQTT packets or
@@ -158,40 +141,32 @@ impl<'buf> Session<'buf> {
 /// The handle owns the transport and borrows the [`Session`] for the duration of the connection.
 /// All network operations (`drive`, `poll`, `recv`, `publish`, `subscribe`, `unsubscribe`,
 /// `disconnect`) live here; session-state queries (`is_pending`, `is_complete`, `can_publish`, …)
-/// are reachable through the [`Deref`](core::ops::Deref) to the underlying [`Session`].
-///
-/// Dropping (or [`mem::forget`](core::mem::forget)-ing) the handle releases the transport and the
-/// session borrow; the same `Session` can then be reconnected with a fresh transport — possibly of
-/// a different `IO` type or buffer lifetime. State needed across reconnects (in-flight QoS replay,
-/// keepalive timers, the inbound packet reader) is reset at the start of the next
-/// [`Session::connect`](Session::connect), so correctness does not depend on this handle's `Drop`
-/// running.
+/// are reachable through the [`Self::session`] method.
 ///
 /// Note that dropping or forgetting the handle is an *ungraceful* MQTT close: **no `DISCONNECT`
-/// packet is sent** (a sync `Drop` cannot perform the async write), so the broker sees an abnormal
-/// disconnect and will publish the configured Will, if any. Whether the underlying transport is
-/// actually closed is up to the `IO`'s own `Drop`. For a clean shutdown — `DISCONNECT` sent, Will
-/// suppressed — call [`disconnect`](Self::disconnect) (or [`disconnect_with`](Self::disconnect_with))
-/// before dropping. Reconnecting afterwards with [`Session::connect`](Session::connect) resumes the
-/// broker session via `CONNECT` `clean_start=false`; see [`ConnectEvent`](crate::ConnectEvent).
+/// packet is sent** (a sync `Drop` cannot perform the async write).
 pub struct Connection<'a, 'buf, IO> {
     pub(super) session: &'a mut Session<'buf>,
     pub(super) io: IO,
     pub(super) event: ConnectEvent,
-}
-
-impl<'buf, IO> core::ops::Deref for Connection<'_, 'buf, IO> {
-    type Target = Session<'buf>;
-
-    fn deref(&self) -> &Self::Target {
-        self.session
-    }
+    pub(super) live: bool,
 }
 
 impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
     /// Whether this connection started a fresh broker session or resumed an existing one.
     pub fn connect_event(&self) -> ConnectEvent {
         self.event
+    }
+
+    /// Return a reference to the underlying session.
+    pub fn session(&self) -> &Session<'buf> {
+        self.session
+    }
+
+    /// Return whether the session is connected and currently has the local capacity to attempt a
+    /// publish at the requested QoS.
+    pub fn can_publish(&self, qos: QoS) -> bool {
+        self.live && self.session.can_publish(qos)
     }
 
     /// Whether the connection is still live.
@@ -202,79 +177,32 @@ impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
     /// further operations fail fast with [`Error::Disconnected`](crate::Error::Disconnected)
     /// instead of driving the dead transport; drop the handle and `connect` again to recover.
     pub fn is_connected(&self) -> bool {
-        self.session.connected
+        self.live
     }
 
-    /// See [`Session`] docs: advance local session state cooperatively without waiting on new
-    /// inbound reads or future deadlines.
-    pub async fn drive(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        self.session.drive(&mut self.io).await
+    /// Return whether the operation still has local in-flight state.
+    pub fn is_pending(&self, op: &Op) -> bool {
+        self.session.is_pending(op)
     }
 
-    /// Wait until any session progress happens or the session disconnects.
-    pub async fn poll(&mut self) -> Result<Option<InboundPublish<'_>>, Error<IO::Error>> {
-        self.session.poll(&mut self.io).await
+    /// Return whether the operation completed in the current session generation.
+    pub fn is_complete(&self, op: &Op) -> bool {
+        self.session.is_complete(op)
     }
 
-    /// Wait until the next inbound publish arrives.
-    pub async fn recv(&mut self) -> Result<InboundPublish<'_>, Error<IO::Error>> {
-        self.session.recv(&mut self.io).await
+    /// Return whether the local session state that could complete this operation was discarded.
+    pub fn is_invalidated(&self, op: &Op) -> bool {
+        self.session.is_invalidated(op)
     }
 
-    /// Send a `SUBSCRIBE`.
-    pub async fn subscribe(
-        &mut self,
-        topics: &[TopicFilter<'_>],
-        properties: &[Property<'_>],
-    ) -> Result<Op, Error<IO::Error>> {
-        self.session
-            .subscribe(&mut self.io, topics, properties)
-            .await
+    /// Return the underlying transport, consuming this handle.
+    pub fn into_inner(mut self) -> IO {
+        self.handle_disconnect();
+        self.io
     }
 
-    /// Send an `UNSUBSCRIBE`.
-    pub async fn unsubscribe(
-        &mut self,
-        topics: &[&str],
-        properties: &[Property<'_>],
-    ) -> Result<Op, Error<IO::Error>> {
-        self.session
-            .unsubscribe(&mut self.io, topics, properties)
-            .await
-    }
-
-    /// Send a `PUBLISH`.
-    pub async fn publish<P>(
-        &mut self,
-        publication: Publication<'_, P>,
-    ) -> Result<Option<Op>, PubError<P::Error, IO::Error>>
-    where
-        P: ToPayload,
-    {
-        self.session.publish(&mut self.io, publication).await
-    }
-
-    /// Gracefully close the transport with `DISCONNECT`.
-    ///
-    /// This is the graceful counterpart to simply dropping the handle: it sends the MQTT
-    /// `DISCONNECT` so the broker closes cleanly and suppresses the Will. Just dropping (or
-    /// [`mem::forget`](core::mem::forget)-ing) the handle skips this and is treated by the broker
-    /// as an abnormal disconnect.
-    ///
-    /// Takes `&mut self` rather than consuming the handle, so a cancelled disconnect can be
-    /// retried. After a successful disconnect the handle's transport is dead; drop it (or
-    /// `mem::forget` it) to release the session for a fresh `connect`.
-    pub async fn disconnect(&mut self) -> Result<(), Error<IO::Error>> {
-        self.session
-            .disconnect_with(&mut self.io, Disconnect::success())
-            .await
-    }
-
-    /// Close the transport with a caller-specified `DISCONNECT`.
-    pub async fn disconnect_with(
-        &mut self,
-        disconnect: Disconnect<'_>,
-    ) -> Result<(), Error<IO::Error>> {
-        self.session.disconnect_with(&mut self.io, disconnect).await
+    pub fn handle_disconnect(&mut self) {
+        self.live = false;
+        self.session.handle_disconnect();
     }
 }

--- a/src/mqtt_client/session/operations.rs
+++ b/src/mqtt_client/session/operations.rs
@@ -12,9 +12,7 @@ use crate::wire::Utf8String;
 use crate::{Connection, Error, Io, Op, Property, PubError, QoS, ResourceError, debug, info, warn};
 
 impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
-    /// Helper backing [`Connection::disconnect`](super::Connection::disconnect) and
-    /// [`Connection::disconnect_with`](super::Connection::disconnect_with): write the `DISCONNECT`
-    /// over the transport. The caller drops the transport afterwards.
+    /// Write the `DISCONNECT` over the transport. The caller drops the transport afterwards.
     ///
     /// Cancel-safe if the underlying transport write/flush futures are cancel-safe.
     pub async fn disconnect_with(
@@ -53,6 +51,8 @@ impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
 
     /// Send a `SUBSCRIBE`.
     ///
+    /// Call this after [`connect`](Self::connect). A resumed [`crate::ConnectEvent::Reconnected`]
+    /// already kept broker-side subscriptions.
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
     pub async fn subscribe(
         &mut self,

--- a/src/mqtt_client/session/operations.rs
+++ b/src/mqtt_client/session/operations.rs
@@ -13,27 +13,18 @@ use crate::{Error, Op, Property, PubError, QoS, ResourceError, debug, info, warn
 
 use super::{Io, Session};
 
-impl<'buf, IO> Session<'buf, IO>
-where
-    IO: Io,
-{
-    /// Gracefully close the current MQTT transport with `DISCONNECT`.
+impl<'buf> Session<'buf> {
+    /// Helper backing [`Connection::disconnect`](super::Connection::disconnect) and
+    /// [`Connection::disconnect_with`](super::Connection::disconnect_with): write the `DISCONNECT`
+    /// over the transport. The caller drops the transport afterwards.
     ///
     /// Cancel-safe if the underlying transport write/flush futures are cancel-safe.
-    pub async fn disconnect(&mut self) -> Result<(), Error<IO::Error>> {
-        self.disconnect_with(Disconnect::success()).await
-    }
-
-    /// Close the current MQTT transport with a caller-specified `DISCONNECT`.
-    ///
-    /// Use [`Disconnect::with_will`] to ask the broker to publish the configured Will immediately.
-    ///
-    /// Cancel-safe if the underlying transport write/flush futures are cancel-safe.
-    pub async fn disconnect_with(
+    pub(super) async fn disconnect_with<IO: Io>(
         &mut self,
+        io: &mut IO,
         disconnect: Disconnect<'_>,
     ) -> Result<(), Error<IO::Error>> {
-        if self.connection.is_none() {
+        if !self.connected {
             return Ok(());
         }
         info!("Graceful disconnect requested");
@@ -45,12 +36,12 @@ where
         let mut buffer = [0u8; CONTROL_PACKET_LEN];
         let packet = MqttSerializer::encode(&mut buffer, &disconnect)?;
         self.runtime.require_packet_size(packet.len())?;
-        let connection = self.connection.as_mut().ok_or(Error::Disconnected)?;
-        let result = match write_all(connection, packet).await {
-            Ok(()) => connection.flush().await.map_err(Error::Transport),
+        let result = match write_all(io, packet).await {
+            Ok(()) => io.flush().await.map_err(Error::Transport),
             Err(err) => Err(err),
         };
-        self.handle_disconnect();
+        // The transport is finished after a DISCONNECT regardless of the write outcome.
+        self.mark_disconnected();
         result
     }
 
@@ -64,12 +55,13 @@ where
     /// [`Session::is_invalidated`](Self::is_invalidated).
     ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
-    pub async fn subscribe(
+    pub(super) async fn subscribe<IO: Io>(
         &mut self,
+        io: &mut IO,
         topics: &[TopicFilter<'_>],
         properties: &[Property<'_>],
     ) -> Result<Op, Error<IO::Error>> {
-        if self.connection.is_none() {
+        if !self.connected {
             return Err(Error::Disconnected);
         }
         if topics.is_empty() {
@@ -78,8 +70,8 @@ where
         if !Properties::from_slice(properties).valid_for(PropertyContext::Subscribe) {
             return Err(Error::InvalidRequest);
         }
-        self.flush_outbound().await?;
-        self.require_retained_slot()?;
+        self.flush_outbound(io).await?;
+        self.require_retained_slot::<IO>()?;
 
         let packet_id = self.data.next_packet_id();
         let (offset, len) = self.data.outbound.encode_packet(&Subscribe {
@@ -96,7 +88,7 @@ where
             len,
             self.data.outbound.used()
         );
-        self.flush_outbound().await?;
+        self.flush_outbound(io).await?;
         Ok(Op::new(
             OpKind::Subscribe,
             packet_id,
@@ -111,12 +103,13 @@ where
     /// [`Session::is_invalidated`](Self::is_invalidated).
     ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
-    pub async fn unsubscribe(
+    pub(super) async fn unsubscribe<IO: Io>(
         &mut self,
+        io: &mut IO,
         topics: &[&str],
         properties: &[Property<'_>],
     ) -> Result<Op, Error<IO::Error>> {
-        if self.connection.is_none() {
+        if !self.connected {
             return Err(Error::Disconnected);
         }
         if topics.is_empty() {
@@ -125,8 +118,8 @@ where
         if !Properties::from_slice(properties).valid_for(PropertyContext::Unsubscribe) {
             return Err(Error::InvalidRequest);
         }
-        self.flush_outbound().await?;
-        self.require_retained_slot()?;
+        self.flush_outbound(io).await?;
+        self.require_retained_slot::<IO>()?;
 
         let packet_id = self.data.next_packet_id();
         let (offset, len) = self.data.outbound.encode_packet(&Unsubscribe {
@@ -143,7 +136,7 @@ where
             len,
             self.data.outbound.used()
         );
-        self.flush_outbound().await?;
+        self.flush_outbound(io).await?;
         Ok(Op::new(
             OpKind::Unsubscribe,
             packet_id,
@@ -163,17 +156,18 @@ where
     /// directly to the transport. It therefore does not consume replay/in-flight slots and only
     /// needs enough currently free TX space for that one encode, but it is not cancel-safe and
     /// returns `None`.
-    pub async fn publish<P>(
+    pub(super) async fn publish<IO: Io, P>(
         &mut self,
+        io: &mut IO,
         publication: Publication<'_, P>,
     ) -> Result<Option<Op>, PubError<P::Error, IO::Error>>
     where
         P: ToPayload,
     {
-        if self.connection.is_none() {
+        if !self.connected {
             return Err(Error::Disconnected.into());
         }
-        self.flush_outbound().await?;
+        self.flush_outbound(io).await?;
 
         let Publication {
             topic,
@@ -199,7 +193,7 @@ where
             dup: false,
         };
         if packet_id.is_some() {
-            self.require_retained_slot()?;
+            self.require_retained_slot::<IO>()?;
         }
 
         if !self.can_publish(qos) {
@@ -220,7 +214,7 @@ where
                 self.runtime.max_send_quota,
                 self.data.outbound.used()
             );
-            self.flush_outbound().await?;
+            self.flush_outbound(io).await?;
             let kind = if qos == QoS::ExactlyOnce {
                 OpKind::PublishExactlyOnce
             } else {
@@ -233,18 +227,17 @@ where
             MqttSerializer::encode_publish(self.data.outbound.scratch_space(), &header, payload)?;
         self.runtime.require_packet_size(packet.len())?;
         debug!("Sending QoS0 PUBLISH len={=usize}", packet.len());
-        let connection = self.connection.as_mut().ok_or(Error::Disconnected)?;
-        if let Err(err) = write_all(connection, packet).await {
+        if let Err(err) = write_all(io, packet).await {
             if matches!(err, Error::WriteZero) {
                 return Err(err.into());
             }
             warn!("QoS0 PUBLISH write failed");
-            self.handle_disconnect();
+            self.mark_disconnected();
             return Err(err.into());
         }
-        if let Err(err) = connection.flush().await {
+        if let Err(err) = io.flush().await {
             warn!("QoS0 PUBLISH flush failed: {}", err.kind());
-            self.handle_disconnect();
+            self.mark_disconnected();
             return Err(Error::Transport(err).into());
         }
         self.runtime.note_outbound_activity(Instant::now());
@@ -252,7 +245,7 @@ where
         Ok(None)
     }
 
-    pub(super) fn require_retained_slot(&self) -> Result<(), Error<IO::Error>> {
+    pub(super) fn require_retained_slot<IO: Io>(&self) -> Result<(), Error<IO::Error>> {
         if self.data.outbound.retained_full() {
             return Err(Error::Resource(ResourceError::InflightExhausted));
         }

--- a/src/mqtt_client/session/operations.rs
+++ b/src/mqtt_client/session/operations.rs
@@ -9,22 +9,19 @@ use crate::publication::{Publication, ToPayload};
 use crate::ser::MqttSerializer;
 use crate::types::TopicFilter;
 use crate::wire::Utf8String;
-use crate::{Error, Op, Property, PubError, QoS, ResourceError, debug, info, warn};
+use crate::{Connection, Error, Io, Op, Property, PubError, QoS, ResourceError, debug, info, warn};
 
-use super::{Io, Session};
-
-impl<'buf> Session<'buf> {
+impl<'buf, IO: Io> Connection<'_, 'buf, IO> {
     /// Helper backing [`Connection::disconnect`](super::Connection::disconnect) and
     /// [`Connection::disconnect_with`](super::Connection::disconnect_with): write the `DISCONNECT`
     /// over the transport. The caller drops the transport afterwards.
     ///
     /// Cancel-safe if the underlying transport write/flush futures are cancel-safe.
-    pub(super) async fn disconnect_with<IO: Io>(
+    pub async fn disconnect_with(
         &mut self,
-        io: &mut IO,
         disconnect: Disconnect<'_>,
     ) -> Result<(), Error<IO::Error>> {
-        if !self.connected {
+        if !self.live {
             return Ok(());
         }
         info!("Graceful disconnect requested");
@@ -35,33 +32,34 @@ impl<'buf> Session<'buf> {
         }
         let mut buffer = [0u8; CONTROL_PACKET_LEN];
         let packet = MqttSerializer::encode(&mut buffer, &disconnect)?;
-        self.runtime.require_packet_size(packet.len())?;
-        let result = match write_all(io, packet).await {
-            Ok(()) => io.flush().await.map_err(Error::Transport),
+        self.session.runtime.require_packet_size(packet.len())?;
+        let result = match write_all(&mut self.io, packet).await {
+            Ok(()) => self.io.flush().await.map_err(Error::Transport),
             Err(err) => Err(err),
         };
         // The transport is finished after a DISCONNECT regardless of the write outcome.
-        self.mark_disconnected();
+        self.handle_disconnect();
         result
+    }
+
+    /// Gracefully close the transport with `DISCONNECT`.
+    ///
+    /// This is the graceful counterpart to simply dropping the handle: it sends the MQTT
+    /// `DISCONNECT` so the broker closes cleanly and suppresses the Will. Just dropping
+    /// the handle skips this and is treated by the broker as an abnormal disconnect.
+    pub async fn disconnect(&mut self) -> Result<(), Error<IO::Error>> {
+        self.disconnect_with(Disconnect::success()).await
     }
 
     /// Send a `SUBSCRIBE`.
     ///
-    /// Call this after [`connect`](Self::connect). A resumed [`crate::ConnectEvent::Reconnected`]
-    /// already kept broker-side subscriptions.
-    ///
-    /// Returns an operation handle that can be checked with [`Session::is_pending`](Self::is_pending),
-    /// [`Session::is_complete`](Self::is_complete), or
-    /// [`Session::is_invalidated`](Self::is_invalidated).
-    ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
-    pub(super) async fn subscribe<IO: Io>(
+    pub async fn subscribe(
         &mut self,
-        io: &mut IO,
         topics: &[TopicFilter<'_>],
         properties: &[Property<'_>],
     ) -> Result<Op, Error<IO::Error>> {
-        if !self.connected {
+        if !self.live {
             return Err(Error::Disconnected);
         }
         if topics.is_empty() {
@@ -70,46 +68,48 @@ impl<'buf> Session<'buf> {
         if !Properties::from_slice(properties).valid_for(PropertyContext::Subscribe) {
             return Err(Error::InvalidRequest);
         }
-        self.flush_outbound(io).await?;
-        self.require_retained_slot::<IO>()?;
+        self.flush_outbound().await?;
+        self.require_retained_slot()?;
 
-        let packet_id = self.data.next_packet_id();
-        let (offset, len) = self.data.outbound.encode_packet(&Subscribe {
+        let packet_id = self.session.data.next_packet_id();
+        let (offset, len) = self.session.data.outbound.encode_packet(&Subscribe {
             packet_id,
             dup: false,
             properties: Properties::from_slice(properties),
             topics,
         })?;
-        self.runtime.require_packet_size(len)?;
-        self.data.outbound.retain_packet(packet_id, offset, len)?;
+        self.session.runtime.require_packet_size(len)?;
+        self.session
+            .data
+            .outbound
+            .retain_packet(packet_id, offset, len)?;
         debug!(
             "Enqueued SUBSCRIBE packet_id={=u16} len={=usize} tx_used={=usize}",
             packet_id,
             len,
-            self.data.outbound.used()
+            self.session.data.outbound.used()
         );
-        self.flush_outbound(io).await?;
+        self.flush_outbound().await?;
         Ok(Op::new(
             OpKind::Subscribe,
             packet_id,
-            self.data.generation(),
+            self.session.data.generation(),
         ))
     }
 
     /// Send an `UNSUBSCRIBE`.
     ///
-    /// Returns an operation handle that can be checked with [`Session::is_pending`](Self::is_pending),
-    /// [`Session::is_complete`](Self::is_complete), or
-    /// [`Session::is_invalidated`](Self::is_invalidated).
+    /// Returns an operation handle that can be checked with [`Connection::is_pending`](Self::is_pending),
+    /// [`Connection::is_complete`](Self::is_complete), or
+    /// [`Connection::is_invalidated`](Self::is_invalidated).
     ///
     /// Cancel-safe if the underlying transport I/O futures are cancel-safe.
-    pub(super) async fn unsubscribe<IO: Io>(
+    pub async fn unsubscribe(
         &mut self,
-        io: &mut IO,
         topics: &[&str],
         properties: &[Property<'_>],
     ) -> Result<Op, Error<IO::Error>> {
-        if !self.connected {
+        if !self.live {
             return Err(Error::Disconnected);
         }
         if topics.is_empty() {
@@ -118,29 +118,32 @@ impl<'buf> Session<'buf> {
         if !Properties::from_slice(properties).valid_for(PropertyContext::Unsubscribe) {
             return Err(Error::InvalidRequest);
         }
-        self.flush_outbound(io).await?;
-        self.require_retained_slot::<IO>()?;
+        self.flush_outbound().await?;
+        self.require_retained_slot()?;
 
-        let packet_id = self.data.next_packet_id();
-        let (offset, len) = self.data.outbound.encode_packet(&Unsubscribe {
+        let packet_id = self.session.data.next_packet_id();
+        let (offset, len) = self.session.data.outbound.encode_packet(&Unsubscribe {
             packet_id,
             dup: false,
             properties: Properties::from_slice(properties),
             topics,
         })?;
-        self.runtime.require_packet_size(len)?;
-        self.data.outbound.retain_packet(packet_id, offset, len)?;
+        self.session.runtime.require_packet_size(len)?;
+        self.session
+            .data
+            .outbound
+            .retain_packet(packet_id, offset, len)?;
         debug!(
             "Enqueued UNSUBSCRIBE packet_id={=u16} len={=usize} tx_used={=usize}",
             packet_id,
             len,
-            self.data.outbound.used()
+            self.session.data.outbound.used()
         );
-        self.flush_outbound(io).await?;
+        self.flush_outbound().await?;
         Ok(Op::new(
             OpKind::Unsubscribe,
             packet_id,
-            self.data.generation(),
+            self.session.data.generation(),
         ))
     }
 
@@ -156,18 +159,17 @@ impl<'buf> Session<'buf> {
     /// directly to the transport. It therefore does not consume replay/in-flight slots and only
     /// needs enough currently free TX space for that one encode, but it is not cancel-safe and
     /// returns `None`.
-    pub(super) async fn publish<IO: Io, P>(
+    pub async fn publish<P>(
         &mut self,
-        io: &mut IO,
         publication: Publication<'_, P>,
     ) -> Result<Option<Op>, PubError<P::Error, IO::Error>>
     where
         P: ToPayload,
     {
-        if !self.connected {
+        if !self.live {
             return Err(Error::Disconnected.into());
         }
-        self.flush_outbound(io).await?;
+        self.flush_outbound().await?;
 
         let Publication {
             topic,
@@ -179,11 +181,11 @@ impl<'buf> Session<'buf> {
         if !properties.valid_for(PropertyContext::Publish) {
             return Err(Error::InvalidRequest.into());
         }
-        let qos = match self.runtime.max_qos {
-            Some(max_qos) if self.downgrade_qos && qos > max_qos => max_qos,
+        let qos = match self.session.runtime.max_qos {
+            Some(max_qos) if self.session.downgrade_qos && qos > max_qos => max_qos,
             _ => qos,
         };
-        let packet_id = (qos > QoS::AtMostOnce).then(|| self.data.next_packet_id());
+        let packet_id = (qos > QoS::AtMostOnce).then(|| self.session.data.next_packet_id());
         let header = PublishHeader {
             topic: Utf8String(topic),
             packet_id,
@@ -193,7 +195,7 @@ impl<'buf> Session<'buf> {
             dup: false,
         };
         if packet_id.is_some() {
-            self.require_retained_slot::<IO>()?;
+            self.require_retained_slot()?;
         }
 
         if !self.can_publish(qos) {
@@ -201,52 +203,69 @@ impl<'buf> Session<'buf> {
         }
 
         if let Some(packet_id) = packet_id {
-            let (offset, len) = self.data.outbound.encode_publish(&header, payload)?;
-            self.runtime.require_packet_size(len)?;
-            self.data.outbound.retain_packet(packet_id, offset, len)?;
-            self.runtime.send_quota = self.runtime.send_quota.saturating_sub(1);
+            let (offset, len) = self
+                .session
+                .data
+                .outbound
+                .encode_publish(&header, payload)?;
+            self.session.runtime.require_packet_size(len)?;
+            self.session
+                .data
+                .outbound
+                .retain_packet(packet_id, offset, len)?;
+            self.session.runtime.send_quota = self.session.runtime.send_quota.saturating_sub(1);
             debug!(
                 "Enqueued PUBLISH packet_id={=u16} qos={} len={=usize} send_quota={=u16}/{=u16} tx_used={=usize}",
                 packet_id,
                 qos,
                 len,
-                self.runtime.send_quota,
-                self.runtime.max_send_quota,
-                self.data.outbound.used()
+                self.session.runtime.send_quota,
+                self.session.runtime.max_send_quota,
+                self.session.data.outbound.used()
             );
-            self.flush_outbound(io).await?;
+            self.flush_outbound().await?;
             let kind = if qos == QoS::ExactlyOnce {
                 OpKind::PublishExactlyOnce
             } else {
                 OpKind::PublishAtLeastOnce
             };
-            return Ok(Some(Op::new(kind, packet_id, self.data.generation())));
+            return Ok(Some(Op::new(
+                kind,
+                packet_id,
+                self.session.data.generation(),
+            )));
         }
 
-        let packet =
-            MqttSerializer::encode_publish(self.data.outbound.scratch_space(), &header, payload)?;
-        self.runtime.require_packet_size(packet.len())?;
+        let packet = MqttSerializer::encode_publish(
+            self.session.data.outbound.scratch_space(),
+            &header,
+            payload,
+        )?;
+        self.session.runtime.require_packet_size(packet.len())?;
         debug!("Sending QoS0 PUBLISH len={=usize}", packet.len());
-        if let Err(err) = write_all(io, packet).await {
+        if !self.live {
+            return Err(Error::Disconnected.into());
+        }
+        if let Err(err) = write_all(&mut self.io, packet).await {
             if matches!(err, Error::WriteZero) {
                 return Err(err.into());
             }
             warn!("QoS0 PUBLISH write failed");
-            self.mark_disconnected();
+            self.handle_disconnect();
             return Err(err.into());
         }
-        if let Err(err) = io.flush().await {
+        if let Err(err) = self.io.flush().await {
             warn!("QoS0 PUBLISH flush failed: {}", err.kind());
-            self.mark_disconnected();
+            self.handle_disconnect();
             return Err(Error::Transport(err).into());
         }
-        self.runtime.note_outbound_activity(Instant::now());
+        self.session.runtime.note_outbound_activity(Instant::now());
 
         Ok(None)
     }
 
-    pub(super) fn require_retained_slot<IO: Io>(&self) -> Result<(), Error<IO::Error>> {
-        if self.data.outbound.retained_full() {
+    pub(super) fn require_retained_slot(&self) -> Result<(), Error<IO::Error>> {
+        if self.session.data.outbound.retained_full() {
             return Err(Error::Resource(ResourceError::InflightExhausted));
         }
         Ok(())

--- a/src/mqtt_client/session/tests.rs
+++ b/src/mqtt_client/session/tests.rs
@@ -1,7 +1,7 @@
 use super::state::ROUND_TRIP_TIMEOUT_MS;
 use crate::ser::MAX_FIXED_HEADER_SIZE;
-use crate::{Buffers, ConfigBuilder, Publication, QoS, tests::block_on};
-use crate::{ConnectEvent, Error, ResourceError, Session};
+use crate::{Buffers, ConfigBuilder, Publication, tests::block_on};
+use crate::{ConnectEvent, Connection, Error, ResourceError, Session};
 use embassy_time::{Duration, Instant};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use std::collections::VecDeque;
@@ -64,14 +64,20 @@ fn session() -> Session<'static> {
     )
 }
 
-/// A session marked as if a transport were already attached, for the white-box tests below that
-/// drive the internal session methods directly without going through the `connect` handshake.
-/// Kept separate from `session()` so that helper still models the genuinely-disconnected
-/// `Session::new` default that the `connect`-path and pure-state tests rely on.
-fn live_session() -> Session<'static> {
-    let mut session = session();
-    session.connected = true;
-    session
+/// Build a live [`Connection`] over a mock transport, bypassing the `connect` handshake, for the
+/// white-box tests below that drive the internal connection methods directly. Kept separate from
+/// `session()` so that helper still models the genuinely-disconnected `Session::new` default that
+/// the `connect`-path and pure-state tests rely on.
+fn live_connection<'a>(
+    session: &'a mut Session<'static>,
+    io: MockConnection,
+) -> Connection<'a, 'static, MockConnection> {
+    Connection {
+        session,
+        io,
+        event: ConnectEvent::Connected,
+        live: true,
+    }
 }
 
 #[test]
@@ -83,34 +89,27 @@ fn session_exposes_local_packet_capacities() {
 }
 
 #[test]
-fn can_publish_requires_a_live_connection() {
-    // A disconnected session cannot publish even when buffer capacity is available.
-    let session = session();
-    assert!(!session.can_publish(QoS::AtMostOnce));
-    assert!(!session.can_publish(QoS::AtLeastOnce));
-
-    // A live connection with free scratch space can publish at QoS 0.
-    let session = live_session();
-    assert!(session.can_publish(QoS::AtMostOnce));
-}
-
-#[test]
 fn maintain_sends_pingreq_when_due() {
     let mut session = session();
-    let mut io = MockConnection::default();
+    let mut conn = live_connection(&mut session, MockConnection::default());
     let now = Instant::now();
-    session.runtime.next_ping = Some(now);
+    conn.session.runtime.next_ping = Some(now);
 
-    block_on(session.service(&mut io, now)).unwrap();
+    block_on(conn.service(now)).unwrap();
 
-    assert!(io.tx.iter().any(|frame| frame.as_slice() == [0xC0, 0x00]));
+    assert!(
+        conn.io
+            .tx
+            .iter()
+            .any(|frame| frame.as_slice() == [0xC0, 0x00])
+    );
     assert_eq!(
-        session.runtime.ping_timeout,
+        conn.session.runtime.ping_timeout,
         Some(now + Duration::from_millis(ROUND_TRIP_TIMEOUT_MS))
     );
     assert_eq!(
-        session.runtime.next_ping,
-        Some(now + session.runtime.keepalive_send_interval().unwrap())
+        conn.session.runtime.next_ping,
+        Some(now + conn.session.runtime.keepalive_send_interval().unwrap())
     );
 }
 
@@ -131,14 +130,15 @@ fn long_keepalive_schedules_ping_before_expiry() {
 #[test]
 fn maintain_does_not_send_second_pingreq_while_waiting_for_pingresp() {
     let mut session = session();
-    let mut io = MockConnection::default();
+    let mut conn = live_connection(&mut session, MockConnection::default());
     let now = Instant::now();
-    session.runtime.next_ping = Some(now);
+    conn.session.runtime.next_ping = Some(now);
 
-    block_on(session.service(&mut io, now)).unwrap();
-    block_on(session.service(&mut io, now + Duration::from_millis(600))).unwrap();
+    block_on(conn.service(now)).unwrap();
+    block_on(conn.service(now + Duration::from_millis(600))).unwrap();
 
-    let pingreqs = io
+    let pingreqs = conn
+        .io
         .tx
         .iter()
         .filter(|frame| frame.as_slice() == [0xC0, 0x00])
@@ -149,79 +149,84 @@ fn maintain_does_not_send_second_pingreq_while_waiting_for_pingresp() {
 #[test]
 fn pingresp_clears_keepalive_timeout() {
     let mut session = session();
-    let mut io = MockConnection::default();
+    let mut conn = live_connection(&mut session, MockConnection::default());
     let now = Instant::now();
-    session.runtime.next_ping = Some(now);
+    conn.session.runtime.next_ping = Some(now);
 
-    block_on(session.service(&mut io, now)).unwrap();
-    io.push_rx(&[0xD0, 0x00]);
+    block_on(conn.service(now)).unwrap();
+    conn.io.push_rx(&[0xD0, 0x00]);
 
-    block_on(session.read_packet(&mut io)).unwrap();
-    let result = session.process_received_packet::<MockConnection>().unwrap();
+    block_on(conn.read_packet()).unwrap();
+    let result = conn.process_received_packet().unwrap();
     assert!(result.is_none());
-    assert_eq!(session.runtime.ping_timeout, None);
-    assert!(session.runtime.next_ping.is_some());
+    assert_eq!(conn.session.runtime.ping_timeout, None);
+    assert!(conn.session.runtime.next_ping.is_some());
 }
 
 #[test]
 fn drive_returns_none_when_waiting_for_read() {
-    let mut session = live_session();
-    let mut io = MockConnection::default();
+    let mut session = session();
+    let mut conn = live_connection(&mut session, MockConnection::default());
 
-    let result = block_on(session.drive(&mut io)).unwrap();
+    let result = block_on(conn.drive()).unwrap();
 
     assert!(result.is_none());
 }
 
 #[test]
 fn poll_returns_none_after_internal_progress() {
-    let mut session = live_session();
-    let mut io = MockConnection::default();
-    session.runtime.next_ping = Some(Instant::now());
+    let mut session = session();
+    let mut conn = live_connection(&mut session, MockConnection::default());
+    conn.session.runtime.next_ping = Some(Instant::now());
 
-    let result = block_on(session.poll(&mut io)).unwrap();
+    let result = block_on(conn.poll()).unwrap();
 
     assert!(result.is_none());
-    assert!(io.tx.iter().any(|frame| frame.as_slice() == [0xC0, 0x00]));
+    assert!(
+        conn.io
+            .tx
+            .iter()
+            .any(|frame| frame.as_slice() == [0xC0, 0x00])
+    );
 }
 
 #[test]
 fn inbound_publish_does_not_refresh_keepalive_deadline() {
-    let mut session = live_session();
-    let mut io = MockConnection::default();
+    let mut session = session();
+    let mut conn = live_connection(&mut session, MockConnection::default());
     let now = Instant::now();
     let deadline = now + Duration::from_secs(1);
-    session.runtime.next_ping = Some(deadline);
-    io.push_rx(&[0x30, 0x05, 0x00, 0x01, b'A', 0x00, 0x05]);
+    conn.session.runtime.next_ping = Some(deadline);
+    conn.io.push_rx(&[0x30, 0x05, 0x00, 0x01, b'A', 0x00, 0x05]);
 
-    let result = block_on(session.poll(&mut io))
+    let result = block_on(conn.poll())
         .unwrap()
         .expect("expected inbound publish");
     assert_eq!(result.topic(), "A", "{result:?}");
-    assert_eq!(session.runtime.next_ping, Some(deadline));
+    assert_eq!(conn.session.runtime.next_ping, Some(deadline));
 }
 
 #[test]
 fn qos0_publish_refreshes_keepalive_deadline() {
-    let mut session = live_session();
-    let mut io = MockConnection::default();
+    let mut session = session();
+    let mut conn = live_connection(&mut session, MockConnection::default());
     let now = Instant::now();
-    session.runtime.next_ping = Some(now);
+    conn.session.runtime.next_ping = Some(now);
 
-    block_on(session.publish(&mut io, Publication::bytes("A", b"5"))).unwrap();
-    assert!(session.runtime.next_ping.is_some_and(
-        |deadline| deadline >= now + session.runtime.keepalive_send_interval().unwrap()
+    block_on(conn.publish(Publication::bytes("A", b"5"))).unwrap();
+    assert!(conn.session.runtime.next_ping.is_some_and(
+        |deadline| deadline >= now + conn.session.runtime.keepalive_send_interval().unwrap()
     ));
 }
 
 #[test]
 fn expired_ping_timeout_disconnects_session() {
     let mut session = session();
-    let mut io = MockConnection::default();
+    let mut conn = live_connection(&mut session, MockConnection::default());
     let now = Instant::now();
-    session.runtime.ping_timeout = Some(now);
+    conn.session.runtime.ping_timeout = Some(now);
 
-    let result = block_on(session.service(&mut io, now));
+    let result = block_on(conn.service(now));
 
     // The session signals the dead connection by surfacing `Disconnected`; the caller drops the
     // transport. Carried-over state is reset on the next `connect`, not here.
@@ -231,14 +236,17 @@ fn expired_ping_timeout_disconnects_session() {
 #[test]
 fn pingreq_write_error_disconnects_session() {
     let mut session = session();
-    let mut io = MockConnection {
-        write_error: Some(ErrorKind::ConnectionReset),
-        ..Default::default()
-    };
+    let mut conn = live_connection(
+        &mut session,
+        MockConnection {
+            write_error: Some(ErrorKind::ConnectionReset),
+            ..Default::default()
+        },
+    );
     let now = Instant::now();
-    session.runtime.next_ping = Some(now);
+    conn.session.runtime.next_ping = Some(now);
 
-    let result = block_on(session.service(&mut io, now));
+    let result = block_on(conn.service(now));
 
     assert!(matches!(
         result,
@@ -289,10 +297,10 @@ fn connect_returns_insufficient_memory_when_tx_is_too_small() {
 
 #[test]
 fn timed_out_read_disconnects_session() {
-    let mut session = live_session();
-    let mut io = MockConnection::default();
+    let mut session = session();
+    let mut conn = live_connection(&mut session, MockConnection::default());
 
-    let result = block_on(session.poll(&mut io));
+    let result = block_on(conn.poll());
 
     assert!(matches!(result, Err(Error::Transport(ErrorKind::TimedOut))));
 }

--- a/src/mqtt_client/session/tests.rs
+++ b/src/mqtt_client/session/tests.rs
@@ -1,7 +1,7 @@
 use super::state::ROUND_TRIP_TIMEOUT_MS;
 use crate::ser::MAX_FIXED_HEADER_SIZE;
 use crate::{Buffers, ConfigBuilder, Publication, tests::block_on};
-use crate::{ConnectEvent, Connection, Error, ResourceError, Session};
+use crate::{ConnectEvent, Connection, Error, QoS, ResourceError, Session};
 use embassy_time::{Duration, Instant};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use std::collections::VecDeque;
@@ -303,4 +303,50 @@ fn timed_out_read_disconnects_session() {
     let result = block_on(conn.poll());
 
     assert!(matches!(result, Err(Error::Transport(ErrorKind::TimedOut))));
+}
+
+#[test]
+fn can_publish_false_after_disconnect() {
+    let mut session = session();
+    let mut conn = live_connection(&mut session, MockConnection::default());
+    assert!(conn.can_publish(QoS::AtMostOnce));
+    assert!(conn.can_publish(QoS::AtLeastOnce));
+
+    conn.handle_disconnect();
+
+    assert!(!conn.can_publish(QoS::AtMostOnce));
+    assert!(!conn.can_publish(QoS::AtLeastOnce));
+    assert!(!conn.can_publish(QoS::ExactlyOnce));
+}
+
+#[test]
+fn can_publish_gates_qos1_2_on_send_quota() {
+    let mut session = session();
+    let conn = live_connection(&mut session, MockConnection::default());
+    conn.session.runtime.send_quota = 0;
+
+    assert!(!conn.can_publish(QoS::AtLeastOnce));
+    assert!(!conn.can_publish(QoS::ExactlyOnce));
+    // QoS0 ignores send_quota.
+    assert!(conn.can_publish(QoS::AtMostOnce));
+}
+
+#[test]
+fn can_publish_qos1_false_when_retained_slots_full() {
+    let mut session = session();
+    let conn = live_connection(&mut session, MockConnection::default());
+    for packet_id in 1u16..=8 {
+        let offset = (packet_id - 1) * 4;
+        conn.session
+            .data
+            .outbound
+            .retain_packet(packet_id, offset as usize, 4)
+            .unwrap();
+    }
+
+    assert_ne!(conn.session.runtime.send_quota, 0);
+    assert!(!conn.can_publish(QoS::AtLeastOnce));
+    assert!(!conn.can_publish(QoS::ExactlyOnce));
+    // QoS0 only needs scratch space, which is still ample.
+    assert!(conn.can_publish(QoS::AtMostOnce));
 }

--- a/src/mqtt_client/session/tests.rs
+++ b/src/mqtt_client/session/tests.rs
@@ -1,6 +1,6 @@
 use super::state::ROUND_TRIP_TIMEOUT_MS;
 use crate::ser::MAX_FIXED_HEADER_SIZE;
-use crate::{Buffers, ConfigBuilder, Publication, tests::block_on};
+use crate::{Buffers, ConfigBuilder, Publication, QoS, tests::block_on};
 use crate::{ConnectEvent, Error, ResourceError, Session};
 use embassy_time::{Duration, Instant};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
@@ -53,7 +53,7 @@ impl Write for MockConnection {
     }
 }
 
-fn session() -> Session<'static, MockConnection> {
+fn session() -> Session<'static> {
     let rx = Box::leak(Box::new([0; 128]));
     let tx = Box::leak(Box::new([0; 1152]));
     Session::new(
@@ -62,6 +62,16 @@ fn session() -> Session<'static, MockConnection> {
             .unwrap()
             .keepalive_interval(1),
     )
+}
+
+/// A session marked as if a transport were already attached, for the white-box tests below that
+/// drive the internal session methods directly without going through the `connect` handshake.
+/// Kept separate from `session()` so that helper still models the genuinely-disconnected
+/// `Session::new` default that the `connect`-path and pure-state tests rely on.
+fn live_session() -> Session<'static> {
+    let mut session = session();
+    session.connected = true;
+    session
 }
 
 #[test]
@@ -73,21 +83,27 @@ fn session_exposes_local_packet_capacities() {
 }
 
 #[test]
+fn can_publish_requires_a_live_connection() {
+    // A disconnected session cannot publish even when buffer capacity is available.
+    let session = session();
+    assert!(!session.can_publish(QoS::AtMostOnce));
+    assert!(!session.can_publish(QoS::AtLeastOnce));
+
+    // A live connection with free scratch space can publish at QoS 0.
+    let session = live_session();
+    assert!(session.can_publish(QoS::AtMostOnce));
+}
+
+#[test]
 fn maintain_sends_pingreq_when_due() {
     let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut io = MockConnection::default();
     let now = Instant::now();
     session.runtime.next_ping = Some(now);
 
-    block_on(session.service(now)).unwrap();
+    block_on(session.service(&mut io, now)).unwrap();
 
-    let connection = session.connection.as_ref().unwrap();
-    assert!(
-        connection
-            .tx
-            .iter()
-            .any(|frame| frame.as_slice() == [0xC0, 0x00])
-    );
+    assert!(io.tx.iter().any(|frame| frame.as_slice() == [0xC0, 0x00]));
     assert_eq!(
         session.runtime.ping_timeout,
         Some(now + Duration::from_millis(ROUND_TRIP_TIMEOUT_MS))
@@ -115,17 +131,14 @@ fn long_keepalive_schedules_ping_before_expiry() {
 #[test]
 fn maintain_does_not_send_second_pingreq_while_waiting_for_pingresp() {
     let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut io = MockConnection::default();
     let now = Instant::now();
     session.runtime.next_ping = Some(now);
 
-    block_on(session.service(now)).unwrap();
-    block_on(session.service(now + Duration::from_millis(600))).unwrap();
+    block_on(session.service(&mut io, now)).unwrap();
+    block_on(session.service(&mut io, now + Duration::from_millis(600))).unwrap();
 
-    let pingreqs = session
-        .connection
-        .as_ref()
-        .unwrap()
+    let pingreqs = io
         .tx
         .iter()
         .filter(|frame| frame.as_slice() == [0xC0, 0x00])
@@ -136,15 +149,15 @@ fn maintain_does_not_send_second_pingreq_while_waiting_for_pingresp() {
 #[test]
 fn pingresp_clears_keepalive_timeout() {
     let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut io = MockConnection::default();
     let now = Instant::now();
     session.runtime.next_ping = Some(now);
 
-    block_on(session.service(now)).unwrap();
-    session.connection.as_mut().unwrap().push_rx(&[0xD0, 0x00]);
+    block_on(session.service(&mut io, now)).unwrap();
+    io.push_rx(&[0xD0, 0x00]);
 
-    block_on(session.read_packet()).unwrap();
-    let result = session.process_received_packet().unwrap();
+    block_on(session.read_packet(&mut io)).unwrap();
+    let result = session.process_received_packet::<MockConnection>().unwrap();
     assert!(result.is_none());
     assert_eq!(session.runtime.ping_timeout, None);
     assert!(session.runtime.next_ping.is_some());
@@ -152,49 +165,36 @@ fn pingresp_clears_keepalive_timeout() {
 
 #[test]
 fn drive_returns_none_when_waiting_for_read() {
-    let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut session = live_session();
+    let mut io = MockConnection::default();
 
-    let result = block_on(session.drive()).unwrap();
+    let result = block_on(session.drive(&mut io)).unwrap();
 
     assert!(result.is_none());
-    assert!(session.connection.is_some());
 }
 
 #[test]
 fn poll_returns_none_after_internal_progress() {
-    let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut session = live_session();
+    let mut io = MockConnection::default();
     session.runtime.next_ping = Some(Instant::now());
 
-    let result = block_on(session.poll()).unwrap();
+    let result = block_on(session.poll(&mut io)).unwrap();
 
     assert!(result.is_none());
-    assert!(
-        session
-            .connection
-            .as_ref()
-            .unwrap()
-            .tx
-            .iter()
-            .any(|frame| frame.as_slice() == [0xC0, 0x00])
-    );
+    assert!(io.tx.iter().any(|frame| frame.as_slice() == [0xC0, 0x00]));
 }
 
 #[test]
 fn inbound_publish_does_not_refresh_keepalive_deadline() {
-    let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut session = live_session();
+    let mut io = MockConnection::default();
     let now = Instant::now();
     let deadline = now + Duration::from_secs(1);
     session.runtime.next_ping = Some(deadline);
-    session
-        .connection
-        .as_mut()
-        .unwrap()
-        .push_rx(&[0x30, 0x05, 0x00, 0x01, b'A', 0x00, 0x05]);
+    io.push_rx(&[0x30, 0x05, 0x00, 0x01, b'A', 0x00, 0x05]);
 
-    let result = block_on(session.poll())
+    let result = block_on(session.poll(&mut io))
         .unwrap()
         .expect("expected inbound publish");
     assert_eq!(result.topic(), "A", "{result:?}");
@@ -203,12 +203,12 @@ fn inbound_publish_does_not_refresh_keepalive_deadline() {
 
 #[test]
 fn qos0_publish_refreshes_keepalive_deadline() {
-    let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut session = live_session();
+    let mut io = MockConnection::default();
     let now = Instant::now();
     session.runtime.next_ping = Some(now);
 
-    block_on(session.publish(Publication::bytes("A", b"5"))).unwrap();
+    block_on(session.publish(&mut io, Publication::bytes("A", b"5"))).unwrap();
     assert!(session.runtime.next_ping.is_some_and(
         |deadline| deadline >= now + session.runtime.keepalive_send_interval().unwrap()
     ));
@@ -217,37 +217,33 @@ fn qos0_publish_refreshes_keepalive_deadline() {
 #[test]
 fn expired_ping_timeout_disconnects_session() {
     let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut io = MockConnection::default();
     let now = Instant::now();
     session.runtime.ping_timeout = Some(now);
 
-    let result = block_on(session.service(now));
+    let result = block_on(session.service(&mut io, now));
 
+    // The session signals the dead connection by surfacing `Disconnected`; the caller drops the
+    // transport. Carried-over state is reset on the next `connect`, not here.
     assert!(matches!(result, Err(Error::Disconnected)));
-    assert!(session.connection.is_none());
-    assert_eq!(session.runtime.ping_timeout, None);
-    assert_eq!(session.runtime.next_ping, None);
 }
 
 #[test]
 fn pingreq_write_error_disconnects_session() {
     let mut session = session();
-    session.connection = Some(MockConnection {
+    let mut io = MockConnection {
         write_error: Some(ErrorKind::ConnectionReset),
         ..Default::default()
-    });
+    };
     let now = Instant::now();
     session.runtime.next_ping = Some(now);
 
-    let result = block_on(session.service(now));
+    let result = block_on(session.service(&mut io, now));
 
     assert!(matches!(
         result,
         Err(Error::Transport(ErrorKind::ConnectionReset))
     ));
-    assert!(session.connection.is_none());
-    assert_eq!(session.runtime.next_ping, None);
-    assert_eq!(session.runtime.ping_timeout, None);
 }
 
 #[test]
@@ -262,12 +258,14 @@ fn connect_uses_tx_buffer_when_rx_only_covers_connack() {
     let mut connection = MockConnection::default();
     connection.push_rx(&[0x20, 0x03, 0x00, 0x00, 0x00]);
 
-    let result = block_on(session.connect(connection));
+    let connection = block_on(session.connect(connection)).unwrap();
 
-    assert!(matches!(result, Ok(ConnectEvent::Connected)));
-    let connection = session.connection.as_ref().unwrap();
-    assert_eq!(connection.tx.len(), 1);
-    assert!(connection.tx[0].len() > rx.len());
+    assert!(matches!(
+        connection.connect_event(),
+        ConnectEvent::Connected
+    ));
+    assert_eq!(connection.io.tx.len(), 1);
+    assert!(connection.io.tx[0].len() > rx.len());
 }
 
 #[test]
@@ -281,7 +279,7 @@ fn connect_returns_insufficient_memory_when_tx_is_too_small() {
     );
     let connection = MockConnection::default();
 
-    let result = block_on(session.connect(connection));
+    let result = block_on(session.connect(connection)).map(|_| ());
 
     assert!(matches!(
         result,
@@ -291,11 +289,10 @@ fn connect_returns_insufficient_memory_when_tx_is_too_small() {
 
 #[test]
 fn timed_out_read_disconnects_session() {
-    let mut session = session();
-    session.connection = Some(MockConnection::default());
+    let mut session = live_session();
+    let mut io = MockConnection::default();
 
-    let result = block_on(session.poll());
+    let result = block_on(session.poll(&mut io));
 
     assert!(matches!(result, Err(Error::Transport(ErrorKind::TimedOut))));
-    assert!(session.connection.is_none());
 }

--- a/tests/async_client.rs
+++ b/tests/async_client.rs
@@ -3,9 +3,13 @@ mod support;
 use embassy_time::{Duration, with_timeout};
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 use minimq::{
-    Buffers, ConfigBuilder, ConnectEvent, Disconnect, Error, InboundPublish, Op, PeerError,
-    Property, PubError, Publication, QoS, ReasonCode, ResourceError, Session, TopicFilter,
+    Buffers, ConfigBuilder, ConnectEvent, Connection, Disconnect, Error, InboundPublish, Op,
+    PeerError, Property, PubError, Publication, QoS, ReasonCode, ResourceError, Session,
+    TopicFilter,
 };
+
+/// A live connection handle over the mock transport, returned by `Session::connect`.
+type Conn<'a> = Connection<'a, 'static, MockConnection>;
 use std::{cell::RefCell, collections::VecDeque, future::poll_fn, rc::Rc, task::Poll};
 use support::{block_on, init_host_logging, poll_once};
 
@@ -337,44 +341,36 @@ fn outbound_pubcomp(id: u16, reason: u8) -> [u8; 5] {
     [0x70, 0x03, (id >> 8) as u8, id as u8, reason]
 }
 
-fn connected_session(connector: &MockConnector) -> Session<'static, MockConnection> {
-    let mut session = session();
-    expect_connected(&mut session, connector);
-    assert!(session.is_connected());
-    session
-}
-
-fn session() -> Session<'static, MockConnection> {
+fn session() -> Session<'static> {
     Session::new(config())
 }
 
-fn expect_connected(session: &mut Session<'static, MockConnection>, connector: &MockConnector) {
-    assert!(matches!(
-        block_on(session.connect(connector.connect().unwrap())).unwrap(),
-        ConnectEvent::Connected
-    ));
+fn expect_connected<'a>(session: &'a mut Session<'static>, connector: &MockConnector) -> Conn<'a> {
+    let conn = block_on(session.connect(connector.connect().unwrap())).unwrap();
+    assert!(matches!(conn.connect_event(), ConnectEvent::Connected));
+    conn
 }
 
-fn expect_reconnected(session: &mut Session<'static, MockConnection>, connector: &MockConnector) {
-    assert!(matches!(
-        block_on(session.connect(connector.connect().unwrap())).unwrap(),
-        ConnectEvent::Reconnected
-    ));
+fn expect_reconnected<'a>(
+    session: &'a mut Session<'static>,
+    connector: &MockConnector,
+) -> Conn<'a> {
+    let conn = block_on(session.connect(connector.connect().unwrap())).unwrap();
+    assert!(matches!(conn.connect_event(), ConnectEvent::Reconnected));
+    conn
 }
 
-fn poll_now<'a>(
-    session: &'a mut Session<'static, MockConnection>,
-) -> Result<Option<InboundPublish<'a>>, Error<ErrorKind>> {
-    match block_on(with_timeout(Duration::from_millis(0), session.poll())) {
+fn poll_now<'a>(conn: &'a mut Conn<'_>) -> Result<Option<InboundPublish<'a>>, Error<ErrorKind>> {
+    match block_on(with_timeout(Duration::from_millis(0), conn.poll())) {
         Ok(Ok(event)) => Ok(event),
         Ok(Err(err)) => Err(err),
         Err(_) => Ok(None),
     }
 }
 
-fn expect_disconnected(session: &mut Session<'static, MockConnection>) {
+fn expect_disconnected(conn: &mut Conn<'_>) {
     for _ in 0..WAIT_STEPS {
-        match poll_now(session) {
+        match poll_now(conn) {
             Err(Error::Disconnected) => return,
             Ok(None) => {}
             other => panic!("unexpected poll result while waiting for disconnect: {other:?}"),
@@ -383,19 +379,13 @@ fn expect_disconnected(session: &mut Session<'static, MockConnection>) {
     panic!("timed out waiting for disconnect");
 }
 
-fn with_inbound<T>(
-    session: &mut Session<'static, MockConnection>,
-    f: impl FnOnce(InboundPublish<'_>) -> T,
-) -> T {
-    f(block_on(session.recv()).unwrap())
+fn with_inbound<T>(conn: &mut Conn<'_>, f: impl FnOnce(InboundPublish<'_>) -> T) -> T {
+    f(block_on(conn.recv()).unwrap())
 }
 
-fn expect_poll_error(
-    session: &mut Session<'static, MockConnection>,
-    want: impl Fn(&Error<ErrorKind>) -> bool,
-) {
+fn expect_poll_error(conn: &mut Conn<'_>, want: impl Fn(&Error<ErrorKind>) -> bool) {
     for _ in 0..WAIT_STEPS {
-        match poll_now(session) {
+        match poll_now(conn) {
             Ok(None) => {}
             Err(err) if want(&err) => return,
             other => panic!("unexpected poll result while waiting for error: {other:?}"),
@@ -404,11 +394,7 @@ fn expect_poll_error(
     panic!("timed out waiting for poll error");
 }
 
-fn wait_for_tx_frame(
-    session: &mut Session<'static, MockConnection>,
-    inspect: &MockConnection,
-    expected: &[u8],
-) {
+fn wait_for_tx_frame(conn: &mut Conn<'_>, inspect: &MockConnection, expected: &[u8]) {
     if inspect
         .tx()
         .iter()
@@ -418,7 +404,7 @@ fn wait_for_tx_frame(
     }
 
     for _ in 0..WAIT_STEPS {
-        match poll_now(session) {
+        match poll_now(conn) {
             Ok(None) | Err(Error::Disconnected) => {}
             other => panic!("unexpected poll result while waiting for tx frame: {other:?}"),
         }
@@ -434,10 +420,10 @@ fn wait_for_tx_frame(
     panic!("timed out waiting for tx frame");
 }
 
-fn fill_inflight_publish_slots(session: &mut Session<'static, MockConnection>) -> usize {
+fn fill_inflight_publish_slots(conn: &mut Conn<'_>) -> usize {
     let mut count = 0;
     loop {
-        match publish_qos1(session, "data", b"x") {
+        match publish_qos1(conn, "data", b"x") {
             Ok(Some(_)) => count += 1,
             Ok(None) => unreachable!("QoS1 publish must return an op handle"),
             Err(PubError::Session(Error::Resource(ResourceError::InflightExhausted))) => {
@@ -449,27 +435,27 @@ fn fill_inflight_publish_slots(session: &mut Session<'static, MockConnection>) -
 }
 
 fn publish_qos1(
-    session: &mut Session<'static, MockConnection>,
+    conn: &mut Conn<'_>,
     topic: &str,
     payload: &[u8],
 ) -> Result<Option<Op>, PubError<(), ErrorKind>> {
-    block_on(session.publish(Publication::bytes(topic, payload).qos(QoS::AtLeastOnce)))
+    block_on(conn.publish(Publication::bytes(topic, payload).qos(QoS::AtLeastOnce)))
 }
 
-fn publish_qos1_ok(session: &mut Session<'static, MockConnection>, topic: &str, payload: &[u8]) {
-    publish_qos1(session, topic, payload).unwrap();
+fn publish_qos1_ok(conn: &mut Conn<'_>, topic: &str, payload: &[u8]) {
+    publish_qos1(conn, topic, payload).unwrap();
 }
 
 fn publish_qos2(
-    session: &mut Session<'static, MockConnection>,
+    conn: &mut Conn<'_>,
     topic: &str,
     payload: &[u8],
 ) -> Result<Option<Op>, PubError<(), ErrorKind>> {
-    block_on(session.publish(Publication::bytes(topic, payload).qos(QoS::ExactlyOnce)))
+    block_on(conn.publish(Publication::bytes(topic, payload).qos(QoS::ExactlyOnce)))
 }
 
-fn publish_qos2_ok(session: &mut Session<'static, MockConnection>, topic: &str, payload: &[u8]) {
-    publish_qos2(session, topic, payload).unwrap();
+fn publish_qos2_ok(conn: &mut Conn<'_>, topic: &str, payload: &[u8]) {
+    publish_qos2(conn, topic, payload).unwrap();
 }
 
 #[test]
@@ -479,8 +465,7 @@ fn fragmented_connack_still_establishes_session() {
     let connector = MockConnector::new(connection);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    assert!(session.is_connected());
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -490,14 +475,15 @@ fn fragmented_inbound_publish_is_assembled_and_acked() {
     connection.push_rx(&connack());
     connection.push_rx_fragmented(&inbound_publish_qos1(7, "data", b"payload"));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    with_inbound(&mut session, |message| {
+    with_inbound(&mut conn, |message| {
         assert_eq!(message.topic(), "data");
         assert_eq!(message.payload(), b"payload");
     });
 
-    wait_for_tx_frame(&mut session, &inspect, &outbound_puback(7));
+    wait_for_tx_frame(&mut conn, &inspect, &outbound_puback(7));
 }
 
 #[test]
@@ -507,14 +493,12 @@ fn publish_requires_connected_session() {
     let connector = MockConnector::new(connection);
     let mut session = session();
 
-    let result = publish_qos1(&mut session, "data", b"payload");
-    assert!(matches!(
-        result,
-        Err(PubError::Session(Error::Disconnected))
-    ));
-
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"payload");
+    // With the handle-based API, a publish is only reachable through a `Connection`,
+    // so "publish requires a connected session" is now a compile-time guarantee:
+    // there is no `Session::publish` to call before `connect`. Verify publishing
+    // works once connected.
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"payload");
 }
 
 #[test]
@@ -524,17 +508,17 @@ fn publish_survives_cancellation_during_pending_write() {
     connection.push_rx(&connack());
     connection.push_rx(&puback(1));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     inspect.pend_writes(1);
-    let mut future =
-        Box::pin(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce)));
+    let mut future = Box::pin(conn.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce)));
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
     assert_eq!(inspect.tx().len(), 1);
-    assert!(poll_now(&mut session).unwrap().is_none());
-    publish_qos1_ok(&mut session, "data", b"y");
+    assert!(poll_now(&mut conn).unwrap().is_none());
+    publish_qos1_ok(&mut conn, "data", b"y");
 }
 
 #[test]
@@ -544,22 +528,22 @@ fn cancelled_publish_still_holds_receive_max_quota() {
     connection.push_rx(&connack_receive_max(1));
     connection.push_rx(&puback(1));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     inspect.pend_writes(1);
-    let mut future =
-        Box::pin(session.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce)));
+    let mut future = Box::pin(conn.publish(Publication::bytes("data", b"x").qos(QoS::AtLeastOnce)));
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
-    let result = publish_qos1(&mut session, "data", b"y");
+    let result = publish_qos1(&mut conn, "data", b"y");
     assert!(matches!(result, Err(PubError::Session(Error::NotReady))));
     for _ in 0..WAIT_STEPS {
-        match publish_qos1(&mut session, "data", b"z") {
+        match publish_qos1(&mut conn, "data", b"z") {
             Ok(Some(_)) => return,
             Ok(None) => unreachable!("QoS1 publish must return an op handle"),
             Err(PubError::Session(Error::NotReady)) => {
-                assert!(poll_now(&mut session).unwrap().is_none());
+                assert!(poll_now(&mut conn).unwrap().is_none());
             }
             other => panic!("unexpected publish result while waiting for quota: {other:?}"),
         }
@@ -574,16 +558,17 @@ fn subscribe_survives_cancellation_during_pending_flush() {
     connection.push_rx(&connack());
     connection.push_rx(&suback(1, 0x01));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     inspect.pend_flushes(1);
     let topics = [TopicFilter::new("data")];
-    let mut future = Box::pin(session.subscribe(&topics, &[]));
+    let mut future = Box::pin(conn.subscribe(&topics, &[]));
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
     assert_eq!(inspect.tx().len(), 2);
-    assert!(poll_now(&mut session).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
     assert_eq!(inspect.tx().len(), 2);
 }
 
@@ -593,15 +578,15 @@ fn poll_survives_cancellation_during_pending_read() {
     let mut inspect = connection.clone();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     inspect.pend_reads(1);
-    let mut future = Box::pin(session.poll());
+    let mut future = Box::pin(conn.poll());
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
-    assert!(session.is_connected());
-    assert!(poll_now(&mut session).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
 }
 
 #[test]
@@ -612,15 +597,16 @@ fn qos2_pubrel_survives_cancellation_during_pending_write() {
     connection.push_rx(&pubrec(1));
     connection.push_rx(&pubcomp(1));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    publish_qos2_ok(&mut session, "data", b"x");
-    assert!(poll_now(&mut session).unwrap().is_none());
+    publish_qos2_ok(&mut conn, "data", b"x");
+    assert!(poll_now(&mut conn).unwrap().is_none());
 
     inspect.pend_writes(1);
     let mut sent_pubrel = false;
     for _ in 0..WAIT_STEPS {
-        match poll_now(&mut session).unwrap() {
+        match poll_now(&mut conn).unwrap() {
             None => {
                 if inspect
                     .tx()
@@ -645,14 +631,15 @@ fn inflight_packets_are_not_replayed_during_normal_poll() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    publish_qos1_ok(&mut session, "data", b"x");
+    publish_qos1_ok(&mut conn, "data", b"x");
     let tx_after_publish = connector.connections.borrow().front().is_none();
     assert!(tx_after_publish);
 
-    assert!(poll_now(&mut session).unwrap().is_none());
-    assert!(poll_now(&mut session).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
 }
 
 #[test]
@@ -668,10 +655,11 @@ fn broker_disconnect_marks_inflight_for_replay_on_resume() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"x");
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"x");
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let _conn = expect_reconnected(&mut session, &connector);
 }
 
 #[test]
@@ -686,9 +674,61 @@ fn broker_disconnect_without_session_resume_reports_connected() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    expect_disconnected(&mut session);
-    expect_connected(&mut session, &connector);
+    let mut conn = expect_connected(&mut session, &connector);
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let _conn = expect_connected(&mut session, &connector);
+}
+
+#[test]
+fn handle_latches_disconnect_and_fails_fast() {
+    // A disconnect observed *while the user still holds the handle* must be latched, so
+    // `is_connected()` reflects it and further operations fail fast instead of driving the dead
+    // transport.
+    let mut connection = MockConnection::default();
+    connection.push_rx(&connack());
+    connection.push_rx(&disconnect());
+    let connector = MockConnector::new(connection);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
+
+    assert!(conn.is_connected());
+    expect_disconnected(&mut conn);
+
+    // The broker DISCONNECT is now latched on the handle.
+    assert!(!conn.is_connected());
+    assert!(matches!(block_on(conn.poll()), Err(Error::Disconnected)));
+    assert!(matches!(
+        publish_qos1(&mut conn, "data", b"x"),
+        Err(PubError::Session(Error::Disconnected))
+    ));
+}
+
+#[test]
+fn dropping_a_live_connection_sends_no_disconnect_and_resumes() {
+    let mut first = MockConnection::default();
+    first.push_rx(&connack());
+    let first_inspect = first.clone();
+    let mut second = MockConnection::default();
+    second.push_rx(&connack_session_present());
+    let connector = MockConnector::with_connections([first, second]);
+    let mut session = session();
+
+    // A healthy, connected session dropped WITHOUT a graceful disconnect.
+    let conn = expect_connected(&mut session, &connector);
+    drop(conn);
+
+    // A bare drop is an ungraceful MQTT close: no DISCONNECT (0xE0) packet is written.
+    assert!(
+        !first_inspect
+            .tx()
+            .iter()
+            .any(|frame| frame.first() == Some(&0xE0)),
+        "dropping the handle must not emit a DISCONNECT packet"
+    );
+
+    // Reconnecting resumes the existing broker session.
+    let _conn = expect_reconnected(&mut session, &connector);
 }
 
 #[test]
@@ -704,8 +744,7 @@ fn failed_connack_disconnects_session_and_allows_reconnect() {
         block_on(session.connect(connector.connect().unwrap())),
         Err(Error::Peer(PeerError::Rejected(ReasonCode::NotAuthorized)))
     ));
-    assert!(!session.is_connected());
-    expect_connected(&mut session, &connector);
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -721,8 +760,7 @@ fn broker_disconnect_during_connect_disconnects_session_and_allows_reconnect() {
         block_on(session.connect(connector.connect().unwrap())),
         Err(Error::Disconnected)
     ));
-    assert!(!session.is_connected());
-    expect_connected(&mut session, &connector);
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -738,7 +776,6 @@ fn zero_receive_maximum_disconnects_session_and_allows_reconnect() {
         block_on(session.connect(connector.connect().unwrap())),
         Err(Error::Peer(PeerError::InvalidPacket))
     ));
-    assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
 }
 
@@ -755,7 +792,6 @@ fn oversized_assigned_client_id_disconnects_session_and_allows_reconnect() {
         block_on(session.connect(connector.connect().unwrap())),
         Err(Error::Peer(PeerError::InvalidPacket))
     ));
-    assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
 }
 
@@ -772,7 +808,6 @@ fn timed_out_connack_disconnects_session_and_allows_reconnect() {
         block_on(session.connect(connector.connect().unwrap())),
         Err(Error::Transport(ErrorKind::TimedOut))
     ));
-    assert!(!session.is_connected());
     expect_connected(&mut session, &connector);
 }
 
@@ -787,11 +822,11 @@ fn malformed_inbound_packet_disconnects_session_and_allows_reconnect() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    expect_poll_error(&mut session, |err| {
+    let mut conn = expect_connected(&mut session, &connector);
+    expect_poll_error(&mut conn, |err| {
         matches!(err, Error::Peer(PeerError::InvalidPacket))
     });
-    assert!(!session.is_connected());
+    drop(conn);
     expect_connected(&mut session, &connector);
 }
 
@@ -800,9 +835,10 @@ fn inflight_metadata_exhaustion_is_reported() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let capacity = fill_inflight_publish_slots(&mut session);
+    let capacity = fill_inflight_publish_slots(&mut conn);
     assert!(capacity > 0);
 }
 
@@ -814,14 +850,15 @@ fn outbound_qos_acks_can_arrive_out_of_order() {
     connection.push_rx(&puback(1));
     connection.push_rx(&puback(3));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     for _ in 0..3 {
-        publish_qos1_ok(&mut session, "data", b"x");
+        publish_qos1_ok(&mut conn, "data", b"x");
     }
-    assert!(poll_now(&mut session).unwrap().is_none());
-    assert!(poll_now(&mut session).unwrap().is_none());
-    assert!(poll_now(&mut session).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
 }
 
 #[test]
@@ -838,12 +875,13 @@ fn subscribe_is_replayed_after_disconnect_until_suback() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    block_on(session.subscribe(&[TopicFilter::new("data")], &[])).unwrap();
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
+    let mut conn = expect_connected(&mut session, &connector);
+    block_on(conn.subscribe(&[TopicFilter::new("data")], &[])).unwrap();
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
     wait_for_tx_frame(
-        &mut session,
+        &mut conn,
         &inspect,
         &[
             0x8A, 0x0A, 0x00, 0x01, 0x00, 0x00, 0x04, b'd', b'a', b't', b'a', 0x00,
@@ -864,11 +902,12 @@ fn subscribe_reports_inflight_metadata_exhaustion_before_send() {
     let inspect = connection.clone();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let capacity = fill_inflight_publish_slots(&mut session);
+    let capacity = fill_inflight_publish_slots(&mut conn);
 
-    let result = block_on(session.subscribe(&[TopicFilter::new("data")], &[]));
+    let result = block_on(conn.subscribe(&[TopicFilter::new("data")], &[]));
     assert!(matches!(
         result,
         Err(Error::Resource(ResourceError::InflightExhausted))
@@ -881,10 +920,11 @@ fn subscribe_rejects_empty_topic_list() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     assert!(matches!(
-        block_on(session.subscribe(&[], &[])),
+        block_on(conn.subscribe(&[], &[])),
         Err(Error::InvalidRequest)
     ));
 }
@@ -894,10 +934,11 @@ fn unsubscribe_rejects_empty_topic_list() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     assert!(matches!(
-        block_on(session.unsubscribe(&[], &[])),
+        block_on(conn.unsubscribe(&[], &[])),
         Err(Error::InvalidRequest)
     ));
 }
@@ -911,14 +952,15 @@ fn outbound_qos2_flow_allows_out_of_order_pubrec_and_pubcomp() {
     connection.push_rx(&pubcomp(2));
     connection.push_rx(&pubcomp(1));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     for _ in 0..2 {
-        publish_qos2_ok(&mut session, "data", b"x");
+        publish_qos2_ok(&mut conn, "data", b"x");
     }
 
     for _ in 0..4 {
-        assert!(poll_now(&mut session).unwrap().is_none());
+        assert!(poll_now(&mut conn).unwrap().is_none());
     }
 }
 
@@ -929,13 +971,14 @@ fn inbound_qos2_marks_pending_until_pubrel() {
     connection.push_rx(&inbound_publish_qos2(9, "data", b"x"));
     connection.push_rx(&pubrel(9));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    with_inbound(&mut session, |message| {
+    with_inbound(&mut conn, |message| {
         assert_eq!(message.topic(), "data");
     });
 
-    assert!(poll_now(&mut session).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
 }
 
 #[test]
@@ -954,12 +997,13 @@ fn resumed_session_suppresses_duplicate_inbound_qos2_publish() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    with_inbound(&mut session, |message| assert_eq!(message.topic(), "data"));
+    let mut conn = expect_connected(&mut session, &connector);
+    with_inbound(&mut conn, |message| assert_eq!(message.topic(), "data"));
 
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
-    wait_for_tx_frame(&mut session, &second_inspect, &outbound_pubcomp(9, 0x00));
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    wait_for_tx_frame(&mut conn, &second_inspect, &outbound_pubcomp(9, 0x00));
 
     let tx = second_inspect.tx();
     assert_eq!(
@@ -989,12 +1033,13 @@ fn fresh_session_clears_pending_inbound_qos2_state() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    with_inbound(&mut session, |message| assert_eq!(message.topic(), "data"));
+    let mut conn = expect_connected(&mut session, &connector);
+    with_inbound(&mut conn, |message| assert_eq!(message.topic(), "data"));
 
-    expect_disconnected(&mut session);
-    expect_connected(&mut session, &connector);
-    wait_for_tx_frame(&mut session, &second_inspect, &outbound_pubcomp(9, 0x92));
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_connected(&mut session, &connector);
+    wait_for_tx_frame(&mut conn, &second_inspect, &outbound_pubcomp(9, 0x92));
 
     assert!(
         second_inspect
@@ -1011,14 +1056,15 @@ fn full_retained_outbound_still_sends_puback() {
     connection.push_rx(&connack());
     connection.push_rx(&inbound_publish_qos1(9, "data", b"x"));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let capacity = fill_inflight_publish_slots(&mut session);
+    let capacity = fill_inflight_publish_slots(&mut conn);
     assert!(capacity > 0);
 
-    with_inbound(&mut session, |message| assert_eq!(message.topic(), "data"));
+    with_inbound(&mut conn, |message| assert_eq!(message.topic(), "data"));
 
-    wait_for_tx_frame(&mut session, &inspect, &outbound_puback(9));
+    wait_for_tx_frame(&mut conn, &inspect, &outbound_puback(9));
 }
 
 #[test]
@@ -1028,14 +1074,15 @@ fn full_retained_outbound_still_sends_pubrec() {
     connection.push_rx(&connack());
     connection.push_rx(&inbound_publish_qos2(9, "data", b"x"));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let capacity = fill_inflight_publish_slots(&mut session);
+    let capacity = fill_inflight_publish_slots(&mut conn);
     assert!(capacity > 0);
 
-    with_inbound(&mut session, |message| assert_eq!(message.topic(), "data"));
+    with_inbound(&mut conn, |message| assert_eq!(message.topic(), "data"));
 
-    wait_for_tx_frame(&mut session, &inspect, &outbound_pubrec(9));
+    wait_for_tx_frame(&mut conn, &inspect, &outbound_pubrec(9));
 }
 
 #[test]
@@ -1043,12 +1090,13 @@ fn connack_receive_maximum_clamps_local_quota() {
     let mut connection = MockConnection::default();
     connection.push_rx(&connack_receive_max(2));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    publish_qos1_ok(&mut session, "data", b"x");
-    publish_qos1_ok(&mut session, "data", b"x");
+    publish_qos1_ok(&mut conn, "data", b"x");
+    publish_qos1_ok(&mut conn, "data", b"x");
 
-    let result = publish_qos1(&mut session, "data", b"x");
+    let result = publish_qos1(&mut conn, "data", b"x");
     assert!(matches!(result, Err(PubError::Session(Error::NotReady))));
 }
 
@@ -1058,16 +1106,17 @@ fn session_allows_publish_after_message_borrow_is_dropped() {
     connection.push_rx(&connack());
     connection.push_rx(&inbound_publish_qos1(7, "cmd", b"payload"));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     {
-        with_inbound(&mut session, |message| {
+        with_inbound(&mut conn, |message| {
             assert_eq!(message.topic(), "cmd");
             assert_eq!(message.payload(), b"payload");
         });
     }
 
-    publish_qos1_ok(&mut session, "reply", b"ok");
+    publish_qos1_ok(&mut conn, "reply", b"ok");
 }
 
 #[test]
@@ -1082,15 +1131,16 @@ fn session_reconnects_after_write_error() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    let error = publish_qos1(&mut session, "reply", b"ok").unwrap_err();
+    let mut conn = expect_connected(&mut session, &connector);
+    let error = publish_qos1(&mut conn, "reply", b"ok").unwrap_err();
     assert!(matches!(
         error,
         PubError::Session(Error::Transport(ErrorKind::ConnectionReset))
     ));
+    drop(conn);
 
-    expect_reconnected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "reply", b"ok");
+    let mut conn = expect_reconnected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "reply", b"ok");
 }
 
 #[test]
@@ -1099,16 +1149,17 @@ fn puback_failure_is_reported_and_clears_inflight() {
     connection.push_rx(&connack());
     connection.push_rx(&puback_reason(1, 0x87));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    publish_qos1_ok(&mut session, "data", b"x");
-    expect_poll_error(&mut session, |err| {
+    publish_qos1_ok(&mut conn, "data", b"x");
+    expect_poll_error(&mut conn, |err| {
         matches!(
             err,
             Error::Peer(PeerError::Rejected(ReasonCode::NotAuthorized))
         )
     });
-    publish_qos1_ok(&mut session, "data", b"y");
+    publish_qos1_ok(&mut conn, "data", b"y");
 }
 
 #[test]
@@ -1117,16 +1168,17 @@ fn pubrec_failure_is_reported_and_clears_inflight() {
     connection.push_rx(&connack());
     connection.push_rx(&pubrec_reason(1, 0x97));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    publish_qos2_ok(&mut session, "data", b"x");
-    expect_poll_error(&mut session, |err| {
+    publish_qos2_ok(&mut conn, "data", b"x");
+    expect_poll_error(&mut conn, |err| {
         matches!(
             err,
             Error::Peer(PeerError::Rejected(ReasonCode::QuotaExceeded))
         )
     });
-    publish_qos2_ok(&mut session, "data", b"y");
+    publish_qos2_ok(&mut conn, "data", b"y");
 }
 
 #[test]
@@ -1136,27 +1188,30 @@ fn pubcomp_failure_is_reported_and_clears_release_state() {
     connection.push_rx(&pubrec(1));
     connection.push_rx(&pubcomp_reason(1, 0x83));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    publish_qos2_ok(&mut session, "data", b"x");
-    expect_poll_error(&mut session, |err| {
+    publish_qos2_ok(&mut conn, "data", b"x");
+    expect_poll_error(&mut conn, |err| {
         matches!(
             err,
             Error::Peer(PeerError::Rejected(ReasonCode::ImplementationError))
         )
     });
-    publish_qos2_ok(&mut session, "data", b"y");
+    publish_qos2_ok(&mut conn, "data", b"y");
 }
 
 #[test]
 fn poll_requires_connected_session() {
+    // Polling is only possible through the `Conn` handle returned by `session.connect(..)`;
+    // a fresh `session()` has no handle, so there is nothing to poll. This verifies that
+    // connecting yields a usable handle.
     let mut connection = MockConnection::default();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
     let mut session = session();
 
-    assert!(matches!(block_on(session.poll()), Err(Error::Disconnected)));
-    expect_connected(&mut session, &connector);
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -1176,9 +1231,9 @@ fn connect_retries_cleanly_after_cancellation_during_pending_write() {
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
-    assert!(!session.is_connected());
-    assert!(matches!(block_on(session.poll()), Err(Error::Disconnected)));
-    expect_connected(&mut session, &connector);
+    // After cancellation the session is not connected (no Conn handle exists).
+    // A subsequent connect with the second mock IO must succeed.
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -1198,9 +1253,9 @@ fn connect_retries_cleanly_after_cancellation_during_pending_connack() {
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
-    assert!(!session.is_connected());
-    assert!(matches!(block_on(session.poll()), Err(Error::Disconnected)));
-    expect_connected(&mut session, &connector);
+    // After cancellation the session is not connected (no Conn handle exists).
+    // A subsequent connect with the second mock IO must succeed.
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -1209,11 +1264,13 @@ fn disconnect_sends_disconnect_packet_and_drops_connection() {
     let inspect = connection.clone();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    block_on(session.disconnect()).unwrap();
+    // `disconnect` consumes the handle, so after this the session is no
+    // longer connected (no live Conn borrow).
+    block_on(conn.disconnect()).unwrap();
 
-    assert!(!session.is_connected());
     assert_eq!(inspect.tx().last().unwrap(), &disconnect_req());
 }
 
@@ -1223,11 +1280,12 @@ fn disconnect_with_sends_reason_and_drops_connection() {
     let inspect = connection.clone();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    block_on(session.disconnect_with(Disconnect::with_will())).unwrap();
+    // `disconnect_with` consumes the handle.
+    block_on(conn.disconnect_with(Disconnect::with_will())).unwrap();
 
-    assert!(!session.is_connected());
     assert_eq!(inspect.tx().last().unwrap(), &disconnect_with_will());
 }
 
@@ -1244,39 +1302,40 @@ fn disconnect_uses_dedicated_control_storage_when_tx_arena_is_full() {
     let inspect = connection.clone();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    expect_connected(&mut session, &connector);
+    let mut conn = expect_connected(&mut session, &connector);
 
     let payload = [0u8; 80];
-    block_on(session.publish(Publication::bytes("data", &payload).qos(QoS::AtLeastOnce))).unwrap();
+    block_on(conn.publish(Publication::bytes("data", &payload).qos(QoS::AtLeastOnce))).unwrap();
 
-    block_on(session.disconnect()).unwrap();
+    // `disconnect` consumes the handle.
+    block_on(conn.disconnect()).unwrap();
 
-    assert!(!session.is_connected());
     assert_eq!(inspect.tx().last().unwrap(), &disconnect_req());
 }
 
 #[test]
 fn outbound_operations_reject_invalid_property_contexts() {
-    let connection = MockConnection::default();
-    connection.clone().push_rx(&connack());
+    let mut connection = MockConnection::default();
+    connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     let publish_props = [Property::ServerReference("server")];
     assert_eq!(
-        block_on(session.publish(Publication::bytes("data", b"x").properties(&publish_props))),
+        block_on(conn.publish(Publication::bytes("data", b"x").properties(&publish_props))),
         Err(PubError::Session(Error::InvalidRequest))
     );
 
     let subscribe_props = [Property::ResponseTopic("reply")];
     assert_eq!(
-        block_on(session.subscribe(&[TopicFilter::new("data")], &subscribe_props)),
+        block_on(conn.subscribe(&[TopicFilter::new("data")], &subscribe_props)),
         Err(Error::InvalidRequest)
     );
 
     let disconnect_props = [Property::PayloadFormatIndicator(1)];
     assert_eq!(
-        block_on(session.disconnect_with(Disconnect::success().with_properties(&disconnect_props))),
+        block_on(conn.disconnect_with(Disconnect::success().with_properties(&disconnect_props))),
         Err(Error::InvalidRequest)
     );
 }
@@ -1287,16 +1346,15 @@ fn disconnect_survives_cancellation_during_pending_write() {
     let mut inspect = connection.clone();
     connection.push_rx(&connack());
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
     inspect.pend_writes(1);
-    let mut future = Box::pin(session.disconnect());
+    let mut future = Box::pin(conn.disconnect());
     assert!(matches!(poll_once(future.as_mut()), Poll::Pending));
     drop(future);
 
-    assert!(session.is_connected());
-    block_on(session.disconnect()).unwrap();
-    assert!(!session.is_connected());
+    block_on(conn.disconnect()).unwrap();
     assert_eq!(inspect.tx().last().unwrap(), &disconnect_req());
 }
 
@@ -1316,16 +1374,18 @@ fn session_reconnects_after_replay_write_error() {
     let connector = MockConnector::with_connections([first, second, third]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"x");
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"x");
 
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
     assert!(matches!(
-        block_on(session.poll()),
+        block_on(conn.poll()),
         Err(Error::Transport(ErrorKind::ConnectionReset))
     ));
-    expect_reconnected(&mut session, &connector);
+    drop(conn);
+    let _conn = expect_reconnected(&mut session, &connector);
 }
 
 #[test]
@@ -1347,14 +1407,16 @@ fn qos1_publish_replays_across_multiple_resumed_reconnects() {
     let connector = MockConnector::with_connections([first, second, third]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"x");
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"x");
 
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
-    assert!(poll_now(&mut session).unwrap().is_none());
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    assert!(poll_now(&mut conn).unwrap().is_none());
 
     assert!(
         second_inspect
@@ -1390,20 +1452,23 @@ fn qos2_pubrel_replays_across_multiple_resumed_reconnects() {
     let connector = MockConnector::with_connections([first, second, third]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos2_ok(&mut session, "data", b"x");
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos2_ok(&mut conn, "data", b"x");
 
-    match poll_now(&mut session) {
-        Ok(None) | Err(Error::Disconnected) => {}
+    let already_disconnected = match poll_now(&mut conn) {
+        Ok(None) => false,
+        Err(Error::Disconnected) => true,
         other => panic!("unexpected poll result before disconnect: {other:?}"),
+    };
+    if !already_disconnected {
+        expect_disconnected(&mut conn);
     }
-    if session.is_connected() {
-        expect_disconnected(&mut session);
-    }
-    expect_reconnected(&mut session, &connector);
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
-    assert!(poll_now(&mut session).unwrap().is_none());
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    assert!(poll_now(&mut conn).unwrap().is_none());
 
     assert!(
         second_inspect
@@ -1432,12 +1497,13 @@ fn fresh_session_after_reconnect_drops_stale_replay_state() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"x");
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"x");
 
-    expect_disconnected(&mut session);
-    expect_connected(&mut session, &connector);
-    assert!(poll_now(&mut session).unwrap().is_none());
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_connected(&mut session, &connector);
+    assert!(poll_now(&mut conn).unwrap().is_none());
 
     assert!(
         second_inspect
@@ -1463,16 +1529,18 @@ fn fresh_session_failed_connack_still_drops_stale_replay_state() {
     let connector = MockConnector::with_connections([first, second, third]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"x");
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"x");
 
-    expect_disconnected(&mut session);
+    expect_disconnected(&mut conn);
+    drop(conn);
+    // second connect fails with InvalidPacket (zero receive_max); no conn is bound
     assert!(matches!(
         block_on(session.connect(connector.connect().unwrap())),
         Err(Error::Peer(PeerError::InvalidPacket))
     ));
-    expect_connected(&mut session, &connector);
-    assert!(poll_now(&mut session).unwrap().is_none());
+    let mut conn = expect_connected(&mut session, &connector);
+    assert!(poll_now(&mut conn).unwrap().is_none());
 
     assert!(
         third_inspect
@@ -1496,13 +1564,14 @@ fn stale_puback_after_resumed_replay_is_ignored() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    publish_qos1_ok(&mut session, "data", b"x");
+    let mut conn = expect_connected(&mut session, &connector);
+    publish_qos1_ok(&mut conn, "data", b"x");
 
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
-    assert!(poll_now(&mut session).unwrap().is_none());
-    assert!(poll_now(&mut session).unwrap().is_none());
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    assert!(poll_now(&mut conn).unwrap().is_none());
+    assert!(poll_now(&mut conn).unwrap().is_none());
 }
 
 #[test]
@@ -1521,10 +1590,8 @@ fn connect_uses_configured_session_expiry_interval() {
         .session_expiry_interval(7),
     );
 
-    assert!(matches!(
-        block_on(session.connect(connector.connect().unwrap())).unwrap(),
-        ConnectEvent::Connected
-    ));
+    let conn = block_on(session.connect(connector.connect().unwrap())).unwrap();
+    assert!(matches!(conn.connect_event(), ConnectEvent::Connected));
     assert!(
         inspect
             .tx()
@@ -1541,9 +1608,10 @@ fn publish_rejects_packets_larger_than_broker_maximum() {
     let inspect = connection.clone();
     connection.push_rx(&connack_max_packet_size(8));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let result = block_on(session.publish(Publication::bytes("data", b"x")));
+    let result = block_on(conn.publish(Publication::bytes("data", b"x")));
     assert!(matches!(
         result,
         Err(PubError::Session(Error::Resource(
@@ -1563,12 +1631,14 @@ fn oversized_required_ack_disconnects_session() {
     second.push_rx(&connack());
 
     let connector = MockConnector::with_connections([first, second]);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    expect_poll_error(&mut session, |err| {
+    expect_poll_error(&mut conn, |err| {
         matches!(err, Error::Resource(ResourceError::PacketTooLarge))
     });
-    expect_connected(&mut session, &connector);
+    drop(conn);
+    let _conn = expect_connected(&mut session, &connector);
 }
 
 #[test]
@@ -1578,13 +1648,14 @@ fn successful_required_ack_fits_small_broker_maximum_packet_size() {
     connection.push_rx(&connack_max_packet_size(5));
     connection.push_rx(&inbound_publish_qos1(9, "data", b"x"));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    with_inbound(&mut session, |message| {
+    with_inbound(&mut conn, |message| {
         assert_eq!(message.topic(), "data");
         assert_eq!(message.payload(), b"x");
     });
-    wait_for_tx_frame(&mut session, &inspect, &outbound_puback(9));
+    wait_for_tx_frame(&mut conn, &inspect, &outbound_puback(9));
 }
 
 #[test]
@@ -1601,11 +1672,12 @@ fn unsubscribe_replays_until_unsuback() {
     let connector = MockConnector::with_connections([first, second]);
     let mut session = session();
 
-    expect_connected(&mut session, &connector);
-    block_on(session.unsubscribe(&["data"], &[])).unwrap();
-    expect_disconnected(&mut session);
-    expect_reconnected(&mut session, &connector);
-    assert!(poll_now(&mut session).unwrap().is_none());
+    let mut conn = expect_connected(&mut session, &connector);
+    block_on(conn.unsubscribe(&["data"], &[])).unwrap();
+    expect_disconnected(&mut conn);
+    drop(conn);
+    let mut conn = expect_reconnected(&mut session, &connector);
+    assert!(poll_now(&mut conn).unwrap().is_none());
 
     assert_eq!(
         inspect.tx().last().unwrap(),
@@ -1621,9 +1693,10 @@ fn unsubscribe_rejects_packets_larger_than_broker_maximum() {
     let inspect = connection.clone();
     connection.push_rx(&connack_max_packet_size(8));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let result = block_on(session.unsubscribe(&["data"], &[]));
+    let result = block_on(conn.unsubscribe(&["data"], &[]));
     assert!(matches!(
         result,
         Err(Error::Resource(ResourceError::PacketTooLarge))
@@ -1637,9 +1710,10 @@ fn subscribe_rejects_packets_larger_than_broker_maximum() {
     let inspect = connection.clone();
     connection.push_rx(&connack_max_packet_size(8));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
 
-    let result = block_on(session.subscribe(&[TopicFilter::new("data")], &[]));
+    let result = block_on(conn.subscribe(&[TopicFilter::new("data")], &[]));
     assert!(matches!(
         result,
         Err(Error::Resource(ResourceError::PacketTooLarge))
@@ -1658,8 +1732,9 @@ fn inbound_publish_exposes_response_helpers() {
         b"abc",
     ));
     let connector = MockConnector::new(connection);
-    let mut session = connected_session(&connector);
-    with_inbound(&mut session, |message| {
+    let mut session = session();
+    let mut conn = expect_connected(&mut session, &connector);
+    with_inbound(&mut conn, |message| {
         assert_eq!(message.response_topic(), Some("reply/topic"));
         assert_eq!(message.correlation_data(), Some(&b"abc"[..]));
         let owned_via_message = message.reply_owned::<64, 8>().unwrap().unwrap();

--- a/tests/real_broker.rs
+++ b/tests/real_broker.rs
@@ -6,8 +6,8 @@ use core::task::Poll;
 use embassy_time::{Duration, with_timeout};
 use embedded_io_async::{ErrorType, Read, Write};
 use minimq::{
-    Buffers, ConfigBuilder, ConnectEvent, Error, Publication, QoS, Session, SubscriptionOptions,
-    TopicFilter,
+    Buffers, ConfigBuilder, ConnectEvent, Connection, Error, Publication, QoS, Session,
+    SubscriptionOptions, TopicFilter,
 };
 use std::{
     net::SocketAddr,
@@ -21,6 +21,8 @@ use tokio::{
 
 const BROKER_ADDR_ENV: &str = "MINIMQ_REAL_BROKER_ADDR";
 const BROKER_HOST_ENV: &str = "MINIMQ_REAL_BROKER_HOST";
+
+type Conn<'a, 'buf> = Connection<'a, 'buf, TokioConnection>;
 
 fn socket_broker() -> Option<SocketAddr> {
     let raw = std::env::var(BROKER_ADDR_ENV).ok()?;
@@ -111,14 +113,14 @@ async fn connect_host(host: &str, port: u16) -> std::io::Result<TokioConnection>
 }
 
 async fn poll_until_ready(
-    session: &mut Session<'_, TokioConnection>,
+    conn: &mut Conn<'_, '_>,
     want_inbound: bool,
 ) -> Option<(String, Vec<u8>, QoS)> {
     for _ in 0..200 {
         let result = if want_inbound {
-            Ok(session.poll().await)
+            Ok(conn.poll().await)
         } else {
-            with_timeout(Duration::from_millis(0), session.poll()).await
+            with_timeout(Duration::from_millis(0), conn.poll()).await
         };
         match result {
             Ok(Ok(Some(message))) if want_inbound => {
@@ -143,33 +145,36 @@ async fn poll_until_ready(
 }
 
 async fn assert_roundtrip(
-    subscriber: &mut Session<'_, TokioConnection>,
-    publisher: &mut Session<'_, TokioConnection>,
+    subscriber: &mut Session<'_>,
+    publisher: &mut Session<'_>,
     subscriber_io: TokioConnection,
     publisher_io: TokioConnection,
     topic: &str,
     payload: &[u8],
 ) {
+    let mut sub_conn = subscriber.connect(subscriber_io).await.unwrap();
     assert!(matches!(
-        subscriber.connect(subscriber_io).await.unwrap(),
+        sub_conn.connect_event(),
         ConnectEvent::Connected | ConnectEvent::Reconnected
     ));
     let topics = [TopicFilter::new(topic)
         .options(SubscriptionOptions::default().maximum_qos(QoS::AtLeastOnce))];
-    subscriber.subscribe(&topics, &[]).await.unwrap();
-    let _ = poll_until_ready(subscriber, false).await;
+    sub_conn.subscribe(&topics, &[]).await.unwrap();
+    let _ = poll_until_ready(&mut sub_conn, false).await;
 
+    let mut pub_conn = publisher.connect(publisher_io).await.unwrap();
     assert!(matches!(
-        publisher.connect(publisher_io).await.unwrap(),
+        pub_conn.connect_event(),
         ConnectEvent::Connected | ConnectEvent::Reconnected
     ));
-    publisher
+    pub_conn
         .publish(Publication::bytes(topic, payload).qos(QoS::AtLeastOnce))
         .await
         .unwrap();
 
-    let (received_topic, received_payload, received_qos) =
-        poll_until_ready(subscriber, true).await.expect("publish");
+    let (received_topic, received_payload, received_qos) = poll_until_ready(&mut sub_conn, true)
+        .await
+        .expect("publish");
     assert_eq!(received_topic, topic);
     assert_eq!(received_payload, payload);
     assert_eq!(received_qos, QoS::AtLeastOnce);


### PR DESCRIPTION
## Motivation

`Session<'buf, IO>` owns the transport for the whole session lifetime, which bakes a single `IO`
type **and lifetime** into the session type. That makes it impossible to reuse one `Session` across
reconnects when the transport's lifetime differs between connections - most painfully over TLS,
where the record buffers are borrowed for the connection's lifetime and so have to outlive the
session. In practice that forces a fresh allocation (a leak) per connection: the old
`tls_public_broker` example `Box::leak`s a new record-buffer pair every time it connects.

## What changed

`Session` loses its `IO` generic. `Session::connect::<IO>(io)` now returns a
**`Connection<'_, 'buf, IO>`** handle that owns the transport and borrows the session:

```rust
let mut session = Session::new(config);          // no IO in the type
loop {
    let io = open_transport().await?;            // a fresh IO, any lifetime
    let mut conn = session.connect(io).await?;   // handle owns io, borrows session
    let op = conn.publish(/* … */).await?;
    while conn.is_pending(&op) { conn.poll().await?; }
    // conn drops here -> transport (and its buffer borrows) released -> reuse next loop
}
```

- All network operations (`drive`/`poll`/`recv`/`publish`/`subscribe`/`unsubscribe`/`disconnect`)
  live on the handle; session-state queries (`is_pending`, `can_publish`, …) are reachable through
  `Deref` to `Session`. `connect_event()` exposes the `Connected`/`Reconnected` result.
- **`mem::forget`-safe by construction.** The handle may be dropped *or* `mem::forget`-ed at any
  time (e.g. to release a TLS record-buffer borrow without running `Drop`), so correctness can't
  depend on `Drop`. All state carried across reconnects - in-flight QoS replay, keepalive timers,
  the inbound packet reader - is reset at the **start of every `connect()`** instead of in a
  disconnect/`Drop` path. The old `handle_disconnect()` is split accordingly: transport-drop -> the
  handle's ownership; replay/timer/reader resets -> `connect()`; and its liveness latch -> a
  `connected` flag set at the sites that detect a fatal disconnect.
- **`is_connected()` moves to the `Connection` handle** and reports *per-connection* liveness: it
  latches `false` the moment any operation observes a transport- or protocol-level disconnect
  (broker `DISCONNECT`, transport error, keepalive timeout) or a graceful `disconnect`, after which
  further operations fail fast with `Error::Disconnected` instead of driving a dead transport.
- `Connection::disconnect`/`disconnect_with` take `&mut self` so a cancelled disconnect can be
  retried.

## Drop vs. graceful disconnect

Dropping (or `mem::forget`-ing) the handle is an **ungraceful** MQTT close: no `DISCONNECT` packet
is sent (a sync `Drop` cannot perform the async write), so the broker sees an abnormal disconnect
and will publish the configured Will, if any. Reconnecting afterwards resumes the broker session
(`CONNECT` `clean_start=false` -> `Reconnected`). For a clean shutdown - `DISCONNECT` sent, Will
suppressed - call `conn.disconnect().await` before dropping. This is documented on `Connection`,
`connect`, and `disconnect`, and covered by a test asserting a bare drop emits no `DISCONNECT` and
that the next `connect` resumes.

## Showcase

The `tls_public_broker` example is reworked to **own one pair of TLS record buffers and reuse them
across a reconnect** - connect, round-trip, drop the handle, reconnect reusing the same buffers -
with no `Box::leak` and no per-connection allocation. The previous API could not express this.

## Testing

Whole suite green: **68** unit tests, **59** `async_client` integration tests, **2** `real_broker`
tests, **3** doctests - all ported to the handle API, plus new regression tests for the disconnect
latch and the ungraceful-drop/resume behavior.

## Breaking changes

- `Session` loses its `IO` type parameter; `Session::connect()` returns a `Connection` handle.
- Network operations move from `Session` to the handle (queries remain via the handle's `Deref`).
- `is_connected()` moves from `Session` to `Connection`.
- `Connection::disconnect`/`disconnect_with` take `&mut self`.

The README, all examples, and the test suite are updated to match. See the `CHANGELOG.md`
`[Unreleased]` entry.
